### PR TITLE
Code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.pyo
 *~
 \#*\#
-
+*_flymake.py

--- a/database.py
+++ b/database.py
@@ -158,6 +158,7 @@ class Database(object):
     def database_version(self):
         return self._database_version
 
+    @property
     def file_path(self):
         """
         The database filename including path.

--- a/decorator.py
+++ b/decorator.py
@@ -128,13 +128,13 @@ if "--runtime-statistics" in getattr(sys, "argv", []):
     _runtime_statistics = defaultdict(lambda: [0, 0.0])
 
     def _output_runtime_statistics():
-        _runtime_statistics_logger.info(" COUNT      SUM      AVG  ENTRY")
         entries = [(stats[0], stats[1], entry) for entry, stats in _runtime_statistics.iteritems()]
         entries.sort()
         for count, duration, entry in entries:
             if "\n" in entry:
                 _runtime_statistics_logger.info("<<<%s %dx %.2fs %.2fs\n%s\n>>>", sha1(entry).digest().encode("HEX"), count, duration, duration / count, entry)
 
+        _runtime_statistics_logger.info(" COUNT      SUM      AVG  ENTRY")
         for count, duration, entry in entries:
             _runtime_statistics_logger.info("%5dx %7.2fs %7.2fs  %s", count, duration, duration / count, entry.strip().split("\n")[0])
     atexit_register(_output_runtime_statistics)

--- a/decorator.py
+++ b/decorator.py
@@ -149,7 +149,7 @@ if "--runtime-statistics" in getattr(sys, "argv", []):
                     return func(*args, **kargs)
                 finally:
                     end = time()
-                    entry = format_.format(duration=(end - start), function_name=func.__name__, *args, **kargs)
+                    entry = format_.format(function_name=func.__name__, *args, **kargs)
                     _runtime_statistics_logger.debug(entry)
                     stats = _runtime_statistics[entry]
                     stats[0] += 1

--- a/decorator.py
+++ b/decorator.py
@@ -160,6 +160,30 @@ if "--runtime-statistics" in getattr(sys, "argv", []):
 
 else:
     def attach_runtime_statistics(format_):
+        """
+        Keep track of how often and how long a function was called.
+
+        Runtime statistics will only be collected when sys.argv contains '--runtime-statistics'.
+        Otherwise the decorator will not influence the runtime in any way.
+
+        FORMAT_ must be a (unicode)string.  Each unique string tracks individual statistics.
+        FORMAT_ uses the format mini language and has access to all the arguments and keyword
+        arguments of the function.  Furthermore, the function name is available as a keyword
+        argument called 'function_name'.  The python format mini language is described at:
+        http://docs.python.org/2/library/string.html#format-specification-mini-language.
+
+           @attach_runtime_statistics("{function_name} bar={1}, moo={moo}")
+           def foo(self, bar, moo='milk'):
+               pass
+
+           foo(1)
+           foo(2)
+           foo(2)
+
+        After running the above example, the statistics will show that:
+        - 'foo bar=1 moo=milk' was called once
+        - 'foo bar=2 moo=milk' was called twice
+        """
         def helper(func):
             return func
         return helper

--- a/decorator.py
+++ b/decorator.py
@@ -133,11 +133,9 @@ if "--runtime-statistics" in getattr(sys, "argv", []):
         entries.sort()
         for count, duration, entry in entries:
             if "\n" in entry:
-                print "<<<%s %dx %.2fs %.2fs\n%s\n>>>" % (sha1(entry).digest().encode("HEX"), count, duration, duration / count, entry)
                 _runtime_statistics_logger.info("<<<%s %dx %.2fs %.2fs\n%s\n>>>", sha1(entry).digest().encode("HEX"), count, duration, duration / count, entry)
 
         for count, duration, entry in entries:
-            print "%5dx %7.2fs %7.2fs  %s" % (count, duration, duration / count, "<%s>" % sha1(entry).digest().encode("HEX") if "\n" in entry else entry)
             _runtime_statistics_logger.info("%5dx %7.2fs %7.2fs  %s", count, duration, duration / count, entry.strip().split("\n")[0])
     atexit_register(_output_runtime_statistics)
 

--- a/tool/scenarioscript.py
+++ b/tool/scenarioscript.py
@@ -228,7 +228,7 @@ class ScenarioScript(ScriptBase):
         if filepath:
             # clone the database from filepath instead of using a new one
             origional_database_filename = path.join(self._kargs["localcodedir"], filepath)
-            database_filename = self._dispersy.database.file_path()
+            database_filename = self._dispersy.database.file_path
             self.log("scenario-start-clone", source=origional_database_filename, destination=database_filename)
 
             # HACK: close the old database, copy the original database file, and open the new file


### PR DESCRIPTION
API change: https://github.com/boudewijn-tribler/dispersy/commit/e79990417bb3555aa2816a4ed79d8c5c8fdcfe10

Code cleanup: https://github.com/boudewijn-tribler/dispersy/commit/8d83f5e5bb647d7d3195b72891f999fa086e2a9e

Replaced DISPERSY_DEBUG_DATABASE_QUERIES enviromental variable with
--explain-query-plan and --runtime-statistics.

--explain-query-plan will enable the attach_query_plan decorator.
This decorator will run EXPLAIN QUERY PLAN once for every unique query
and output the results to a logger called "explain-query-plan".

--runtime-statistics will enable the attach_runtime_statistics
decorator.  This decorator will count how often the function is called
and how much wall-time was used.  A logger called "runtime-statistics"
will get the results when the python application exits.

Attach_runtime_statistics tracks statistics per string, not per
function (what a profiler does).  The string can be modified based on
the arguments of the function, i.e. for the database we track
different statistics per query by adding the sql statement in the
string.  See https://github.com/boudewijn-tribler/dispersy/commit/e509cb1da2d3925cb636d2edd897f5f1780023bb for more Info.
