### PR TITLE
More candidate/walker related counters.

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -258,7 +258,7 @@ class WalkCandidate(Candidate):
 
     def age(self, now):
         """
-        Returns the time between NOW and the most recent walk or stumble or any of the associated communities.
+        Returns the time between NOW and the most recent walk or stumble in any of the associated communities.
         """
         return now - max(max(timestamps.last_walk, timestamps.last_stumble) for timestamps in self._timestamps.itervalues())
 

--- a/statistics.py
+++ b/statistics.py
@@ -65,6 +65,17 @@ class DispersyStatistics(Statistics):
         self.walk_bootstrap_success = 0
         self.walk_reset = 0
 
+        # nr of outgoing introduction-request messages with payload.advice == True
+        self.walk_advice_outgoing_request = 0
+        # nr of incoming introduction-response messages that introduce a candidate
+        self.walk_advice_incoming_response = 0
+        # nr of incoming introduction-response messages that introduce a previously unknown candidate
+        self.walk_advice_incoming_response_new = 0
+        # nr of incoming introduction-request messages with payload.advice == True
+        self.walk_advice_incoming_request = 0
+        # nr of outgoing introduction-response messages that introduce a candidate
+        self.walk_advice_outgoing_response = 0
+
         self.wan_address = None
         self.update()
 


### PR DESCRIPTION
Also: outputs statistics in both debug and optimized when logger is enabled (previously would always generate statistics in debug)

So enable the `"dispersy-stats-candidates"` or `"dispersy-stats-detailed-candidates"` logger to see more stuff.
