### PR TITLE
Removes Candidate.is(_any)_active(...).

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -225,29 +225,6 @@ class WalkCandidate(Candidate):
         else:
             return False
 
-    def is_active(self, community, now):
-        """
-        Returns True if SELF is either walk or stumble in COMMUNITY.
-        """
-        timestamps = self._timestamps.get(community.cid)
-        if timestamps:
-            return (timestamps.last_walk + timestamps.timeout_adjustment <= now < timestamps.last_walk + CANDIDATE_WALK_LIFETIME or
-                    now < timestamps.last_stumble + CANDIDATE_STUMBLE_LIFETIME)
-        return False
-
-    def is_any_active(self, now):
-        """
-        Returns True if SELF is either walk or stumble in any of the associated communities.
-
-        This is used when deciding if this candidate can be used for communication, the assumption
-        is that if any community is still active, that all will still be active.  The exception to
-        this rule is when a node decides to leave one or more communities while remaining active in
-        one or more others.
-        """
-        return any(timestamps.last_walk + timestamps.timeout_adjustment <= now < timestamps.last_walk + CANDIDATE_WALK_LIFETIME or now < timestamps.last_stumble + CANDIDATE_STUMBLE_LIFETIME
-                   for timestamps
-                   in self._timestamps.itervalues())
-
     def is_all_obsolete(self, now):
         """
         Returns True if SELF exceeded the CANDIDATE_LIFETIME of all the associated communities.

--- a/community.py
+++ b/community.py
@@ -1128,7 +1128,7 @@ class Community(object):
         now = time()
 
         def acceptable_global_time_helper():
-            options = sorted(global_time for global_time in (candidate.get_global_time(self) for candidate in self._dispersy.candidates if candidate.get_category(self, now) in (u"walk", u"stumble")) if global_time > 0)
+            options = sorted(global_time for global_time in (candidate.get_global_time(self) for candidate in self.dispersy_yield_verified_candidates()) if global_time > 0)
 
             if len(options) > 5:
                 # note: officially when the number of options is even, the median is the average between the

--- a/community.py
+++ b/community.py
@@ -1128,7 +1128,7 @@ class Community(object):
         now = time()
 
         def acceptable_global_time_helper():
-            options = sorted(global_time for global_time in (candidate.get_global_time(self) for candidate in self._dispersy.candidates if candidate.in_community(self, now) and candidate.is_any_active(now)) if global_time > 0)
+            options = sorted(global_time for global_time in (candidate.get_global_time(self) for candidate in self._dispersy.candidates if candidate.get_category(self, now) in (u"walk", u"stumble")) if global_time > 0)
 
             if len(options) > 5:
                 # note: officially when the number of options is even, the median is the average between the
@@ -1353,7 +1353,6 @@ class Community(object):
                 candidate = self._candidates.get(key)
 
                 if (candidate and
-                    candidate.is_any_active(now) and
                     candidate.get_category(self, now) == category):
                     assert candidate.in_community(self, now)
 
@@ -1385,7 +1384,6 @@ class Community(object):
                 candidate = self._candidates.get(key)
 
                 if (candidate and
-                    candidate.is_any_active(now) and
                     candidate.get_category(self, now) in categories):
                     assert candidate.in_community(self, now)
 
@@ -1432,7 +1430,7 @@ class Community(object):
         assert all(not sock_address in self._candidates for sock_address in self._dispersy._bootstrap_candidates.iterkeys()), "none of the bootstrap candidates may be in self._candidates"
 
         now = time()
-        candidates = [candidate for candidate in self._candidates.itervalues() if candidate.is_any_active(now)]
+        candidates = [candidate for candidate in self._candidates.itervalues() if candidate.get_category(self, now) in (u"walk", u"stumble", u"intro")]
         shuffle(candidates)
         return iter(candidates)
 
@@ -1446,7 +1444,7 @@ class Community(object):
         assert all(not sock_address in self._candidates for sock_address in self._dispersy._bootstrap_candidates.iterkeys()), "none of the bootstrap candidates may be in self._candidates"
 
         now = time()
-        candidates = [candidate for candidate in self._candidates.itervalues() if candidate.is_any_active(now) and candidate.get_category(self, now) in (u"walk", u"stumble")]
+        candidates = [candidate for candidate in self._candidates.itervalues() if candidate.get_category(self, now) in (u"walk", u"stumble")]
         shuffle(candidates)
         return iter(candidates)
 

--- a/dispersy.py
+++ b/dispersy.py
@@ -4661,6 +4661,13 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                 self.wan_address_unvote(candidate)
 
     def _stats_candidates(self):
+        """
+        Periodically logs the number of walk and stumble candidates for all communities.
+
+        Enable this output by enabling INFO logging for a logger named "dispersy-stats-candidates".
+
+        Exception: all PreviewChannelCommunity are filter out of the results.
+        """
         logger = logging.getLogger("dispersy-stats-candidates")
         while logger.isEnabledFor(logging.INFO):
             yield 5.0
@@ -4675,6 +4682,13 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                             "" if community.dispersy_enable_candidate_walker else "*", ", ".join(str(candidate) for candidate in candidates[:5]))
 
     def _stats_detailed_candidates(self):
+        """
+        Periodically logs a detailed list of all candidates (walk, stumble, intro, none) for all communities.
+
+        Enable this output by enabling INFO logging for a logger named "dispersy-stats-detailed-candidates".
+
+        Exception: all PreviewChannelCommunity are filter out of the results.
+        """
         logger = logging.getLogger("dispersy-stats-detailed-candidates")
         while logger.isEnabledFor(logging.INFO):
             yield 5.0

--- a/dispersy.py
+++ b/dispersy.py
@@ -4670,7 +4670,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                 if community.get_classification() == u"PreviewChannelCommunity":
                     continue
 
-                candidates = [candidate for candidate in self._candidates.itervalues() if candidate.in_community(community, now) and candidate.is_any_active(now)]
+                candidates = [candidate for candidate in self._candidates.itervalues() if candidate.get_category(community, now) in (u"walk", u"stumble")]
                 logger.info(" %s %20s with %d%s candidates[:5] %s",
                             community.cid.encode("HEX"), community.get_classification(), len(candidates),
                             "" if community.dispersy_enable_candidate_walker else "*", ", ".join(str(candidate) for candidate in candidates[:5]))
@@ -4709,7 +4709,6 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                     for candidate in candidates:
                         logger.info("%4ds %s%s%s%s %-7s %-13s %s",
                                     min(candidate.age(now), 9999),
-                                    "A " if candidate.is_any_active(now) else " I",
                                     "O" if candidate.is_all_obsolete(now) else " ",
                                     "E" if candidate.is_eligible_for_walk(community, now) else " ",
                                     "B" if isinstance(candidate, BootstrapCandidate) else " ",

--- a/dispersy.py
+++ b/dispersy.py
@@ -4664,13 +4664,12 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         logger = logging.getLogger("dispersy-stats-candidates")
         while logger.isEnabledFor(logging.INFO):
             yield 5.0
-            now = time()
             logger.info("--- %s:%d (%s:%d) %s", self.lan_address[0], self.lan_address[1], self.wan_address[0], self.wan_address[1], self.connection_type)
             for community in sorted(self._communities.itervalues(), key=lambda community: community.cid):
                 if community.get_classification() == u"PreviewChannelCommunity":
                     continue
 
-                candidates = [candidate for candidate in self._candidates.itervalues() if candidate.get_category(community, now) in (u"walk", u"stumble")]
+                candidates = sorted(community.dispersy_yield_verified_candidates())
                 logger.info(" %s %20s with %d%s candidates[:5] %s",
                             community.cid.encode("HEX"), community.get_classification(), len(candidates),
                             "" if community.dispersy_enable_candidate_walker else "*", ", ".join(str(candidate) for candidate in candidates[:5]))
@@ -4693,6 +4692,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                         self._statistics.walk_advice_incoming_response_new,
                         self._statistics.walk_advice_incoming_request,
                         self._statistics.walk_advice_outgoing_response)
+
             for community in sorted(self._communities.itervalues(), key=lambda community: community.cid):
                 if community.get_classification() == u"PreviewChannelCommunity":
                     continue

--- a/tool/tracker.py
+++ b/tool/tracker.py
@@ -134,7 +134,7 @@ class TrackerCommunity(Community):
     def update_strikes(self, now):
         # does the community have any active candidates
         for candidate in self._dispersy.candidates:
-            if candidate.is_active(self, now):
+            if candidate.get_category(self, now) in (u"walk", u"stumble"):
                 self._strikes = 0
                 break
         else:

--- a/tool/tracker.py
+++ b/tool/tracker.py
@@ -133,10 +133,8 @@ class TrackerCommunity(Community):
 
     def update_strikes(self, now):
         # does the community have any active candidates
-        for candidate in self._dispersy.candidates:
-            if candidate.get_category(self, now) in (u"walk", u"stumble"):
-                self._strikes = 0
-                break
+        if any(self.dispersy_yield_verified_candidates()):
+            self._strikes = 0
         else:
             self._strikes += 1
         return self._strikes


### PR DESCRIPTION
Instead of is_active(...) use: get_category(...) in (u"walk", u"stumble")

There is no replacement for is_any_active(...).  Instead the states of
a candidate in other communities no longer influenc each other.
