### PR TITLE
Removed GlobalCandidateCache.

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -139,10 +139,10 @@ class WalkCandidate(Candidate):
         assert is_address(wan_address), wan_address
         return self._lan_address if wan_address[0] == self._wan_address[0] else self._wan_address
 
-    def merge(self, dispersy, other):
+    def merge(self, community, other):
         if __debug__:
-            from .dispersy import Dispersy
-        assert isinstance(dispersy, Dispersy), type(dispersy)
+            from .community import Community
+        assert isinstance(community, Community), type(community)
         assert isinstance(other, WalkCandidate), type(other)
         self._associations.update(other._associations)
 
@@ -153,7 +153,6 @@ class WalkCandidate(Candidate):
                 self._timestamps[cid] = timestamps
 
                 # TODO: this should be improved
-                community = dispersy._communities.get(cid, None)
                 community.add_candidate(self)
 
         for cid, global_time in self._global_times.iteritems():

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -643,12 +643,12 @@ class TestCandidates(DispersyTestFunc):
         candidates.append(c.create_candidate(("1.1.1.1", 3), False, ("192.168.0.1", 1), ("1.1.1.1", 3), u"symmetric-NAT"))
         candidates.append(c.create_candidate(("1.1.1.1", 4), False, ("192.168.0.1", 1), ("1.1.1.1", 4), u"unknown"))
 
-        self._dispersy._filter_duplicate_candidate(candidates[0])
+        c.filter_duplicate_candidate(candidates[0])
 
         expected = [candidates[0].wan_address]
 
         got = []
-        for candidate in self._dispersy._candidates.itervalues():
+        for candidate in c._candidates.itervalues():
             got.append(candidate.wan_address)
 
         self.assertEquals(expected, got)


### PR DESCRIPTION
Since we want all communities to manage their own Candidate, the
GlobalCandidateCache is no longer needed.

Several Candidate related methods have been moved from dispersy.py to
community.py, finally, all references to the GlobalCandidateCache have
been rewritten to use candidates from the community directly.
