### PR TITLE
Candidate instance is no longer aware of communities.

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -57,17 +57,6 @@ class Candidate(object):
         assert is_address(wan_address), wan_address
         return self._sock_addr
 
-    def get_members(self):
-        # TODO this method should be removed, however, it is possibly still used from allchannel/community.py and privatesearch/community.py
-        logger.warning("DEPRECATED.  Please call community.get_candidate(sock_address).get_members() instead!")
-
-        # preferably use the WalkerCandidate directly
-        candidate = community.get_candidate(self._sock_addr)
-        if candidate:
-            return candidate.get_members(community)
-        else:
-            return []
-
     def __str__(self):
         return "{%s:%d}" % self._sock_addr
 

--- a/candidate.py
+++ b/candidate.py
@@ -57,9 +57,12 @@ class Candidate(object):
         assert is_address(wan_address), wan_address
         return self._sock_addr
 
-    def get_members(self, community):
+    def get_members(self):
+        # TODO this method should be removed, however, it is possibly still used from allchannel/community.py and privatesearch/community.py
+        logger.warning("DEPRECATED.  Please call community.get_candidate(sock_address).get_members() instead!")
+
         # preferably use the WalkerCandidate directly
-        candidate = community.dispersy.get_candidate(self._sock_addr)
+        candidate = community.get_candidate(self._sock_addr)
         if candidate:
             return candidate.get_members(community)
         else:
@@ -87,21 +90,6 @@ class WalkCandidate(Candidate):
     - INTRO: we know about this candidate through hearsay.  Viable up to CANDIDATE_INACTIVE seconds
       after the introduction-response message (talking about the candidate) was received.
     """
-    class Timestamps(object):
-        __slots__ = ["timeout_adjustment", "last_walk", "last_stumble", "last_intro"]
-
-        def __init__(self):
-            self.timeout_adjustment = 0.0
-            self.last_walk = 0.0
-            self.last_stumble = 0.0
-            self.last_intro = 0.0
-
-        def merge(self, other):
-            assert isinstance(other, WalkCandidate.Timestamps), other
-            self.timeout_adjustment = max(self.timeout_adjustment, other.timeout_adjustment)
-            self.last_walk = max(self.last_walk, other.last_walk)
-            self.last_stumble = max(self.last_stumble, other.last_stumble)
-            self.last_intro = max(self.last_intro, other.last_intro)
 
     def __init__(self, sock_addr, tunnel, lan_address, wan_address, connection_type):
         assert is_address(sock_addr), sock_addr
@@ -114,9 +102,18 @@ class WalkCandidate(Candidate):
         self._lan_address = lan_address
         self._wan_address = wan_address
         self._connection_type = connection_type
+
+        # Member instances that this Candidate is associated with
         self._associations = set()
-        self._timestamps = dict()
-        self._global_times = dict()
+
+        # properties to determine the category
+        self._timeout_adjustment = 0.0
+        self._last_walk = 0.0
+        self._last_stumble = 0.0
+        self._last_intro = 0.0
+
+        # the highest global time that one of the walks reported from this Candidate
+        self._global_time = 0
 
         if __debug__:
             if not (self.sock_addr == self._lan_address or self.sock_addr == self._wan_address):
@@ -139,220 +136,144 @@ class WalkCandidate(Candidate):
         assert is_address(wan_address), wan_address
         return self._lan_address if wan_address[0] == self._wan_address[0] else self._wan_address
 
-    def merge(self, community, other):
-        if __debug__:
-            from .community import Community
-        assert isinstance(community, Community), type(community)
+    def merge(self, other):
         assert isinstance(other, WalkCandidate), type(other)
         self._associations.update(other._associations)
+        self._timeout_adjustment = max(self._timeout_adjustment, other._timeout_adjustment)
+        self._last_walk = max(self._last_walk, other._last_walk)
+        self._last_stumble = max(self._last_stumble, other._last_stumble)
+        self._last_intro = max(self._last_intro, other._last_intro)
+        self._global_time = max(self._global_time, other._global_time)
 
-        for cid, timestamps in other._timestamps.iteritems():
-            if cid in self._timestamps:
-                self._timestamps[cid].merge(timestamps)
-            else:
-                self._timestamps[cid] = timestamps
+    @property
+    def global_time(self):
+        return self._global_time
 
-                # TODO: this should be improved
-                community.add_candidate(self)
+    @global_time.setter
+    def global_time(self, global_time):
+        self._global_time = max(self._global_time, global_time)
 
-        for cid, global_time in self._global_times.iteritems():
-            self._global_times[cid] = max(self._global_times.get(cid, 0), global_time)
-
-    def set_global_time(self, community, global_time):
-        self._global_times[community.cid] = max(self._global_times.get(community.cid, 0), global_time)
-
-    def get_global_time(self, community):
-        return self._global_times.get(community.cid, 0)
-
-    def _get_or_create_timestamps(self, community):
-        if __debug__:
-            from .community import Community
-            assert isinstance(community, Community)
-        timestamps = self._timestamps.get(community.cid)
-        if not timestamps:
-            self._timestamps[community.cid] = timestamps = self.Timestamps()
-        return timestamps
-
-    def associate(self, community, member):
+    def associate(self, member):
         """
         Once it is confirmed that the candidate is represented by a member, i.e. though a 3-way
         handshake, the member can be associated with the candidate.
         """
-        if __debug__:
-            from .community import Community
-        assert isinstance(community, Community)
         assert isinstance(member, Member)
-        self._associations.add((community.cid, member))
+        self._associations.add(member)
 
-    def is_associated(self, community, member):
+    def is_associated(self, member):
         """
-        Check if the (community, member) pair is associated with this candidate.
+        Check if the member is associated with this candidate.
         """
-        if __debug__:
-            from .community import Community
-        assert isinstance(community, Community)
         assert isinstance(member, Member)
-        return (community.cid, member) in self._associations
+        return member in self._associations
 
-    def disassociate(self, community, member):
+    def disassociate(self, member):
         """
         Remove the association with a member.
         """
-        if __debug__:
-            from .community import Community
-        assert isinstance(community, Community)
         assert isinstance(member, Member)
-        self._associations.remove((community.cid, member))
-        if community.cid in self._global_times:
-            del self._global_times[community.cid]
+        self._associations.remove(member)
 
-    def get_members(self, community):
+    def get_members(self):
         """
-        Returns all unique Member instances in COMMUNITY associated to this candidate.
+        Returns all unique Member instances associated to this candidate.
         """
-        return set(member for cid, member in self._associations if community.cid == cid)
+        return self._associations
 
-    def in_community(self, community, now):
+    def is_obsolete(self, now):
         """
-        Returns True if SELF is either walk, stumble, or intro in COMMUNITY.
+        Returns True if this candidate exceeded the CANDIDATE_LIFETIME.
         """
-        timestamps = self._timestamps.get(community.cid)
-        if timestamps:
-            return (timestamps.last_walk + timestamps.timeout_adjustment <= now < timestamps.last_walk + CANDIDATE_WALK_LIFETIME or
-                    now < timestamps.last_stumble + CANDIDATE_STUMBLE_LIFETIME or
-                    now < timestamps.last_intro + CANDIDATE_INTRO_LIFETIME)
-        else:
-            return False
-
-    def is_all_obsolete(self, now):
-        """
-        Returns True if SELF exceeded the CANDIDATE_LIFETIME of all the associated communities.
-        """
-        return all(max(timestamps.last_walk, timestamps.last_stumble, timestamps.last_intro) + CANDIDATE_LIFETIME < now
-                   for timestamps
-                   in self._timestamps.itervalues())
+        return max(self._last_walk, self._last_stumble, self._last_intro) + CANDIDATE_LIFETIME < now
 
     def age(self, now):
         """
-        Returns the time between NOW and the most recent walk or stumble in any of the associated communities.
+        Returns the time between NOW and the most recent walk or stumble.
         """
-        return now - max(max(timestamps.last_walk, timestamps.last_stumble) for timestamps in self._timestamps.itervalues())
+        return now - max(self._last_walk, self._last_stumble)
 
-    def inactive(self, community, now):
+    def inactive(self, now):
         """
-        Called to set SELF to inactive for COMMUNITY.
+        Called to set this candidate to inactive.
         """
-        timestamps = self._timestamps.get(community.cid)
-        if timestamps:
-            timestamps.last_walk = now - CANDIDATE_WALK_LIFETIME
-            timestamps.last_stumble = now - CANDIDATE_STUMBLE_LIFETIME
-            timestamps.last_intro = now - CANDIDATE_INTRO_LIFETIME
+        self._last_walk = now - CANDIDATE_WALK_LIFETIME
+        self._last_stumble = now - CANDIDATE_STUMBLE_LIFETIME
+        self._last_intro = now - CANDIDATE_INTRO_LIFETIME
 
-    def obsolete(self, community, now):
+    def obsolete(self, now):
         """
-        Called to set SELF to obsolete for all associated communities.
+        Called to set this candidate to obsolete.
         """
-        timestamps = self._timestamps.get(community.cid)
-        if timestamps:
-            timestamps.last_walk = now - CANDIDATE_LIFETIME
-            timestamps.last_stumble = now - CANDIDATE_LIFETIME
-            timestamps.last_intro = now - CANDIDATE_LIFETIME
+        self._last_walk = now - CANDIDATE_LIFETIME
+        self._last_stumble = now - CANDIDATE_LIFETIME
+        self._last_intro = now - CANDIDATE_LIFETIME
 
-    def all_inactive(self, now):
+    def is_eligible_for_walk(self, now):
         """
-        Called to set SELF to inactive (or keep it at OBSOLETE) for all associated communities.
-
-        This is used when a timeout occurs while waiting for an introduction-response.  We choose to
-        set all communities to inactive to improve churn handling.  Setting the entire candidate to
-        inactive will not remove it and any associated 3-way handshake information.  This is
-        retained until the entire candidate becomes obsolete.
-        """
-        for timestamps in self._timestamps.itervalues():
-            timestamps.last_walk = now - CANDIDATE_WALK_LIFETIME
-            timestamps.last_stumble = now - CANDIDATE_STUMBLE_LIFETIME
-            timestamps.last_intro = now - CANDIDATE_INTRO_LIFETIME
-
-    def is_eligible_for_walk(self, community, now):
-        """
-        Returns True when the candidate is eligible for taking a step.
+        Returns True when this candidate is eligible for taking a step.
 
         A candidate is eligible when:
-        - SELF is either walk, stumble, or intro in COMMUNITY; and
+        - SELF is either walk, stumble, or intro; and
         - the previous step is more than CANDIDATE_ELIGIBLE_DELAY ago.
         """
-        timestamps = self._timestamps.get(community.cid)
-        if timestamps:
-            return (timestamps.last_walk + CANDIDATE_ELIGIBLE_DELAY <= now and
-                    (timestamps.last_walk + timestamps.timeout_adjustment <= now < timestamps.last_walk + CANDIDATE_WALK_LIFETIME or
-                     now < timestamps.last_stumble + CANDIDATE_STUMBLE_LIFETIME or
-                     now < timestamps.last_intro + CANDIDATE_INTRO_LIFETIME))
-        else:
-            return False
+        return (self._last_walk + CANDIDATE_ELIGIBLE_DELAY <= now and
+                (self._last_walk + self._timeout_adjustment <= now < self._last_walk + CANDIDATE_WALK_LIFETIME or
+                 now < self._last_stumble + CANDIDATE_STUMBLE_LIFETIME or
+                 now < self._last_intro + CANDIDATE_INTRO_LIFETIME))
 
-    def last_walk(self, community):
-        assert community.cid in self._timestamps
-        return self._timestamps[community.cid].last_walk
+    @property
+    def last_walk(self):
+        return self._last_walk
 
-    def last_stumble(self, community):
-        assert community.cid in self._timestamps
-        return self._timestamps[community.cid].last_stumble
+    @property
+    def last_stumble(self):
+        return self._last_stumble
 
-    def last_intro(self, community):
-        assert community.cid in self._timestamps
-        return self._timestamps[community.cid].last_intro
+    @property
+    def last_intro(self):
+        return self._last_intro
 
-    def get_category(self, community, now):
+    def get_category(self, now):
         """
         Returns the category (u"walk", u"stumble", u"intro", or u"none") depending on the current
         time NOW.
         """
-        timestamps = self._timestamps.get(community.cid)
-        if timestamps:
-            if timestamps.last_walk + timestamps.timeout_adjustment <= now < timestamps.last_walk + CANDIDATE_WALK_LIFETIME:
-                return u"walk"
+        if self._last_walk + self._timeout_adjustment <= now < self._last_walk + CANDIDATE_WALK_LIFETIME:
+            return u"walk"
 
-            if now < timestamps.last_stumble + CANDIDATE_STUMBLE_LIFETIME:
-                return u"stumble"
+        if now < self._last_stumble + CANDIDATE_STUMBLE_LIFETIME:
+            return u"stumble"
 
-            if now < timestamps.last_intro + CANDIDATE_INTRO_LIFETIME:
-                return u"intro"
+        if now < self._last_intro + CANDIDATE_INTRO_LIFETIME:
+            return u"intro"
 
         return u"none"
 
-    def walk(self, community, now, timeout_adjustment):
+    def walk(self, now, timeout_adjustment):
         """
         Called when we are about to send an introduction-request to this candidate.
         """
-        timestamps = self._get_or_create_timestamps(community)
-        timestamps.timeout_adjustment = timeout_adjustment
-        timestamps.last_walk = now
+        self._last_walk = now
+        self._timeout_adjustment = timeout_adjustment
 
-        if not isinstance(self, BootstrapCandidate):
-            community.add_candidate(self)
-
-    def walk_response(self, community):
+    def walk_response(self):
         """
         Called when we received an introduction-response to this candidate.
         """
-        self._get_or_create_timestamps(community).timeout_adjustment = 0.0
+        self._timeout_adjustment = 0.0
 
-    def stumble(self, community, now):
+    def stumble(self, now):
         """
         Called when we receive an introduction-request from this candidate.
         """
-        self._get_or_create_timestamps(community).last_stumble = now
+        self._last_stumble = now
 
-        if not isinstance(self, BootstrapCandidate):
-            community.add_candidate(self)
-
-    def intro(self, community, now):
+    def intro(self, now):
         """
         Called when we receive an introduction-response introducing this candidate.
         """
-        self._get_or_create_timestamps(community).last_intro = now
-
-        if not isinstance(self, BootstrapCandidate):
-            community.add_candidate(self)
+        self._last_intro = now
 
     def update(self, tunnel, lan_address, wan_address, connection_type):
         assert isinstance(tunnel, bool)
@@ -388,24 +309,13 @@ class BootstrapCandidate(WalkCandidate):
     def __init__(self, sock_addr, tunnel):
         super(BootstrapCandidate, self).__init__(sock_addr, tunnel, sock_addr, sock_addr, connection_type=u"public")
 
-    def in_community(self, community, now):
-        """
-        Bootstrap nodes are, by definition, in every possible community.
-        """
-        if not community.cid in self._timestamps:
-            self._timestamps[community.cid] = self.Timestamps()
-        return True
-
-    def is_eligible_for_walk(self, community, now):
+    def is_eligible_for_walk(self, now):
         """
         Bootstrap nodes are, by definition, always online, hence the timeouts do not apply.
         """
-        timestamps = self._timestamps.get(community.cid)
-        if timestamps:
-            return now >= timestamps.last_walk + CANDIDATE_ELIGIBLE_BOOTSTRAP_DELAY
-        return True
+        return self._last_walk + CANDIDATE_ELIGIBLE_DELAY <= now
 
-    def is_associated(self, community, member):
+    def is_associated(self, member):
         """
         Bootstrap nodes are, by definition, always associated hence we return true.
         """

--- a/statistics.py
+++ b/statistics.py
@@ -2,7 +2,7 @@ from time import time
 from collections import defaultdict
 
 
-class Statistics():
+class Statistics(object):
 
     @staticmethod
     def dict_inc(dictionary, key, value=1):
@@ -81,8 +81,6 @@ class DispersyStatistics(Statistics):
 
         # nr of candidates introduced/stumbled upon
         self.total_candidates_discovered = 0
-        # nr of times a candidate was known in another community
-        self.total_candidates_overlapped = 0
 
         self.walk_attempt = 0
         self.walk_success = 0
@@ -121,8 +119,6 @@ class DispersyStatistics(Statistics):
                 self.endpoint_recv = defaultdict(int)
                 self.endpoint_send = defaultdict(int)
                 self.bootstrap_candidates = defaultdict(int)
-                self.overlapping_stumble_candidates = defaultdict(int)
-                self.overlapping_intro_candidates = defaultdict(int)
 
                 # SOURCE:INTRODUCED:COUNT nested dictionary
                 self.received_introductions = defaultdict(lambda: defaultdict(int))
@@ -145,8 +141,6 @@ class DispersyStatistics(Statistics):
                 self.endpoint_recv = None
                 self.endpoint_send = None
                 self.bootstrap_candidates = None
-                self.overlapping_stumble_candidates = None
-                self.overlapping_intro_candidates = None
                 self.received_introductions = None
                 self.outgoing_introduction_request = None
                 self.incoming_introduction_response = None
@@ -204,8 +198,6 @@ class DispersyStatistics(Statistics):
             self.endpoint_recv = defaultdict(int)
             self.endpoint_send = defaultdict(int)
             self.bootstrap_candidates = defaultdict(int)
-            self.overlapping_stumble_candidates = defaultdict(int)
-            self.overlapping_intro_candidates = defaultdict(int)
             self.received_introductions = defaultdict(lambda: defaultdict(int))
             self.outgoing_introduction_request = defaultdict(int)
             self.incoming_introduction_response = defaultdict(int)
@@ -241,9 +233,9 @@ class CommunityStatistics(Statistics):
         self.dispersy_enable_candidate_walker_responses = self._community.dispersy_enable_candidate_walker_responses
         self.global_time = self._community.global_time
         now = time()
-        self.candidates = [(candidate.lan_address, candidate.wan_address, candidate.get_global_time(self._community))
+        self.candidates = [(candidate.lan_address, candidate.wan_address, candidate.global_time)
                            for candidate
-                           in self._community._candidates.itervalues() if candidate.get_category(self._community, now) in [u'walk', u'stumble', u'intro']]
+                           in self._community.candidates.itervalues() if candidate.get_category(now) in [u'walk', u'stumble', u'intro']]
         if database:
             self.database = dict(self._community.dispersy.database.execute(u"SELECT meta_message.name, COUNT(sync.id) FROM sync JOIN meta_message ON meta_message.id = sync.meta_message WHERE sync.community = ? GROUP BY sync.meta_message", (self._community.database_id,)))
         else:

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -338,20 +338,20 @@ class TestCandidates(DispersyTestFunc):
         for flags, candidate in zip(all_flags, candidates):
             if "w" in flags:
                 # SELF has performed an outgoing walk to CANDIDATE
-                candidate.walk(community, now, 10.0)
+                candidate.walk(now, 10.0)
             if "r" in flags:
                 # SELF has received an incoming walk response from CANDIDATE
-                candidate.walk_response(community)
+                candidate.walk_response()
             if "e" in flags:
                 # CANDIDATE_ELIGIBLE_DELAY seconds ago SELF performed a successful walk to CANDIDATE
-                candidate.walk(community, now - CANDIDATE_ELIGIBLE_DELAY, 10.0)
-                candidate.walk_response(community)
+                candidate.walk(now - CANDIDATE_ELIGIBLE_DELAY, 10.0)
+                candidate.walk_response()
             if "s" in flags:
                 # SELF has received an incoming walk request from CANDIDATE
-                candidate.stumble(community, now)
+                candidate.stumble(now)
             if "i" in flags:
                 # SELF has received an incoming walk response which introduced CANDIDATE
-                candidate.intro(community, now)
+                candidate.intro(now)
 
         return now
 
@@ -525,7 +525,7 @@ class TestCandidates(DispersyTestFunc):
             candidate = community.dispersy_get_walk_candidate()
             self.assertNotEquals(candidate, None)
             self.assertIn("%s:%d" % candidate.sock_addr, ["%s:%d" % c.sock_addr for c in selection])
-            candidate.walk(community, time(), 10.5)
+            candidate.walk(time(), 10.5)
         for _ in xrange(5):
             candidate = community.dispersy_get_walk_candidate()
             self.assertEquals(candidate, None)
@@ -538,18 +538,8 @@ class TestCandidates(DispersyTestFunc):
         now = time()
         got = []
         for candidate in candidates:
-            candidate.stumble(community, now)
+            candidate.stumble(now)
             introduce = community.dispersy_get_introduce_candidate(candidate)
-            got.append(introduce.sock_addr if introduce else None)
-        self.assertEquals(expected, got)
-
-        # ordering should not interfere between communities
-        community2 = community_create_method(self._dispersy, self._my_member)
-        expected = [None, ("127.0.0.1", 5), ("127.0.0.1", 4), ("127.0.0.1", 3), ("127.0.0.1", 2)]
-        got = []
-        for candidate in reversed(candidates):
-            candidate.stumble(community2, now)
-            introduce = community2.dispersy_get_introduce_candidate(candidate)
             got.append(introduce.sock_addr if introduce else None)
         self.assertEquals(expected, got)
 
@@ -562,12 +552,12 @@ class TestCandidates(DispersyTestFunc):
         # trackers should not prefer either stumbled or walked candidates, i.e. it should not return
         # candidate 1 more than once/in the wrong position
         now = time()
-        candidates[0].walk(community, now, 10.5)
-        candidates[0].walk_response(community)
+        candidates[0].walk(now, 10.5)
+        candidates[0].walk_response()
         expected = [("127.0.0.1", 5), ("127.0.0.1", 1), ("127.0.0.1", 2), ("127.0.0.1", 3), ("127.0.0.1", 4)]
         got = []
         for candidate in candidates:
-            candidate.stumble(community, now)
+            candidate.stumble(now)
             introduce = community.dispersy_get_introduce_candidate(candidate)
             got.append(introduce.sock_addr if introduce else None)
         self.assertEquals(expected, got)
@@ -584,9 +574,9 @@ class TestCandidates(DispersyTestFunc):
 
         # mark 1 candidate as walk, 1 as stumble
         now = time()
-        candidates[0].walk(c, now, 10.5)
-        candidates[0].walk_response(c)
-        candidates[1].stumble(c, now)
+        candidates[0].walk(now, 10.5)
+        candidates[0].walk_response()
+        candidates[1].stumble(now)
 
         # fetch candidates
         returned_walked_candidate = 0
@@ -609,10 +599,10 @@ class TestCandidates(DispersyTestFunc):
 
         # mark 1 candidate as walk, 1 as stumble
         now = time()
-        candidates[0].walk(c, now - CANDIDATE_ELIGIBLE_DELAY, 10.5)
-        candidates[0].walk_response(c)
-        candidates[1].stumble(c, now)
-        candidates[2].intro(c, now)
+        candidates[0].walk(now - CANDIDATE_ELIGIBLE_DELAY, 10.5)
+        candidates[0].walk_response()
+        candidates[1].stumble(now)
+        candidates[2].intro(now)
 
         # fetch candidates
         returned_walked_candidate = 0

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -73,7 +73,7 @@ class TestOverlay(DispersyTestFunc):
                     eligible_candidates = [candidate
                                            for candidate
                                            in chain(self._dispersy.bootstrap_candidates)
-                                           if candidate.is_eligible_for_walk(self, now)]
+                                           if candidate.is_eligible_for_walk(now)]
                     for count, candidate in enumerate(eligible_candidates[:len(eligible_candidates) / 2], 1):
                         logger.debug("%d/%d extra walk to %s", count, len(eligible_candidates), candidate)
                         self.create_introduction_request(candidate, allow_sync=False)
@@ -82,7 +82,7 @@ class TestOverlay(DispersyTestFunc):
                     eligible_candidates = [candidate
                                            for candidate
                                            in self._candidates.itervalues()
-                                           if candidate.is_eligible_for_walk(self, now)]
+                                           if candidate.is_eligible_for_walk(now)]
                     for count, candidate in enumerate(eligible_candidates[:len(eligible_candidates) / 2], 1):
                         logger.debug("%d/%d extra walk to %s", count, len(eligible_candidates), candidate)
                         self.create_introduction_request(candidate, allow_sync=False)
@@ -111,8 +111,8 @@ class TestOverlay(DispersyTestFunc):
             now = time()
             info = Info()
             info.diff = now - begin
-            info.candidates = [(candidate, candidate.get_category(community, now)) for candidate in community._candidates.itervalues()]
-            info.verified_candidates = [(candidate, candidate.get_category(community, now)) for candidate in community.dispersy_yield_verified_candidates()]
+            info.candidates = [(candidate, candidate.get_category(now)) for candidate in community._candidates.itervalues()]
+            info.verified_candidates = [(candidate, candidate.get_category(now)) for candidate in community.dispersy_yield_verified_candidates()]
             info.bootstrap_attempt = self._dispersy.statistics.walk_bootstrap_attempt
             info.bootstrap_success = self._dispersy.statistics.walk_bootstrap_success
             info.bootstrap_ratio = 100.0 * info.bootstrap_success / info.bootstrap_attempt if info.bootstrap_attempt else 0.0


### PR DESCRIPTION
previously the candidate instance contained information on a per
community basis.  This meant that most methods contained an argument
to identify the community for which an event occurred.

We have changed the candidate to no longer be aware of communities.
This means that:
- all arguments specifying a community have been removed,
- some methods have been removed entirely (i.e. those that exclusively
  worked on all communities), and
- some methods have been rewritten to properties (i.e. those that no
  longer have any arguments).

All changes outside candidate.py reflect changes to handle these API
changes.
