### PR TITLE
Prevent the endpoint from blocking.

### DIFF
--- a/endpoint.py
+++ b/endpoint.py
@@ -82,6 +82,8 @@ class NullEndpoint(Endpoint):
         return self._address
 
     def send(self, candidates, packets):
+        if any(len(packet) > 2**16 - 60 for packet in packets):
+            raise RuntimeError("UDP does not support %d byte packets" % len(max(len(packet) for packet in packets)))
         self._total_up += sum(len(packet) for packet in packets) * len(candidates)
 
 
@@ -163,6 +165,8 @@ class RawserverEndpoint(Endpoint):
         assert isinstance(packets, (tuple, list, set)), type(packets)
         assert all(isinstance(packet, str) for packet in packets)
         assert all(len(packet) > 0 for packet in packets)
+        if any(len(packet) > 2**16 - 60 for packet in packets):
+            raise RuntimeError("UDP does not support %d byte packets" % len(max(len(packet) for packet in packets)))
 
         self._total_up += sum(len(data) for data in packets) * len(candidates)
         self._total_send += (len(packets) * len(candidates))
@@ -351,6 +355,8 @@ class TunnelEndpoint(Endpoint):
         assert isinstance(packets, (tuple, list, set)), type(packets)
         assert all(isinstance(packet, str) for packet in packets)
         assert all(len(packet) > 0 for packet in packets)
+        if any(len(packet) > 2**16 - 60 for packet in packets):
+            raise RuntimeError("UDP does not support %d byte packets" % len(max(len(packet) for packet in packets)))
 
         self._total_up += sum(len(data) for data in packets) * len(candidates)
         self._total_send += (len(packets) * len(candidates))


### PR DESCRIPTION
UDP packets that are larger than 2^16 (including IP header) are
impossible to sent and will cause the endpoint to block.  When such a
thing occurs we will now raise a helpful exception.
