### PR TITLE
Removes MemberDestination.

### DIFF
--- a/community.py
+++ b/community.py
@@ -1330,8 +1330,8 @@ class Community(object):
         return self._dispersy.create_identity(self, sign_with_master, store, update)
 
     @documentation(Dispersy.create_signature_request)
-    def create_dispersy_signature_request(self, message, response_func, response_args=(), timeout=10.0, forward=True):
-        return self._dispersy.create_signature_request(self, message, response_func, response_args, timeout, forward)
+    def create_dispersy_signature_request(self, candidates, message, response_func, response_args=(), timeout=10.0, forward=True):
+        return self._dispersy.create_signature_request(self, candidates, message, response_func, response_args, timeout, forward)
 
     @documentation(Dispersy.create_destroy_community)
     def create_dispersy_destroy_community(self, degree, sign_with_master=False, store=True, update=True, forward=True):

--- a/community.py
+++ b/community.py
@@ -1330,8 +1330,8 @@ class Community(object):
         return self._dispersy.create_identity(self, sign_with_master, store, update)
 
     @documentation(Dispersy.create_signature_request)
-    def create_dispersy_signature_request(self, candidates, message, response_func, response_args=(), timeout=10.0, forward=True):
-        return self._dispersy.create_signature_request(self, candidates, message, response_func, response_args, timeout, forward)
+    def create_dispersy_signature_request(self, candidate, message, response_func, response_args=(), timeout=10.0, forward=True):
+        return self._dispersy.create_signature_request(self, candidate, message, response_func, response_args, timeout, forward)
 
     @documentation(Dispersy.create_destroy_community)
     def create_dispersy_destroy_community(self, degree, sign_with_master=False, store=True, update=True, forward=True):

--- a/conversion.py
+++ b/conversion.py
@@ -10,7 +10,7 @@ from random import choice
 from .authentication import NoAuthentication, MemberAuthentication, DoubleMemberAuthentication
 from .bloomfilter import BloomFilter
 from .crypto import ec_check_public_bin
-from .destination import MemberDestination, CommunityDestination, CandidateDestination
+from .destination import CommunityDestination, CandidateDestination
 from .distribution import FullSyncDistribution, LastSyncDistribution, DirectDistribution
 from .message import DelayPacketByMissingMember, DropPacket, Message
 from .resolution import PublicResolution, LinearResolution, DynamicResolution
@@ -270,8 +270,7 @@ class BinaryConversion(Conversion):
                    LastSyncDistribution: self._decode_last_sync_distribution,
 
                    CandidateDestination: self._decode_empty_destination,
-                   CommunityDestination: self._decode_empty_destination,
-                   MemberDestination: self._decode_empty_destination}
+                   CommunityDestination: self._decode_empty_destination}
 
         self._decode_message_map[byte] = self.DecodeFunctions(meta, mapping[type(meta.authentication)], mapping[type(meta.resolution)], mapping[type(meta.distribution)], mapping[type(meta.destination)], decode_payload_func)
 

--- a/destination.py
+++ b/destination.py
@@ -36,48 +36,15 @@ class CandidateDestination(Destination):
             """
             if __debug__:
                 from .candidate import Candidate
-            assert isinstance(candidates, tuple)
-            assert len(candidates) >= 0
-            assert all(isinstance(candidate, Candidate) for candidate in candidates)
+            assert isinstance(candidates, tuple), type(candidates)
+            assert len(candidates) >= 0, len(candidates)
+            assert all(isinstance(candidate, Candidate) for candidate in candidates), [type(candidate) for candidate in candidates]
             super(CandidateDestination.Implementation, self).__init__(meta)
             self._candidates = candidates
 
         @property
         def candidates(self):
             return self._candidates
-
-
-class MemberDestination(Destination):
-
-    """
-    A destination policy where the message is sent to one or more specified Members.
-
-    Note that the Member objects need to be translated into an address.  This is done using the
-    candidates that are currently online.  As this candidate list constantly changes (random walk,
-    timeout, churn, etc.) it is possible that no address can be found.  In this case the message can
-    not be sent and will be silently dropped.
-    """
-    class Implementation(Destination.Implementation):
-
-        def __init__(self, meta, *members):
-            """
-            Construct an AddressDestination.Implementation object.
-
-            META the associated MemberDestination object.
-
-            MEMBERS is a tuple containing one or more Member instances.  These will be used to try
-            to find the destination addresses when the associated message is sent.
-            """
-            if __debug__:
-                from .member import Member
-            assert len(members) >= 0
-            assert all(isinstance(member, Member) for member in members)
-            super(MemberDestination.Implementation, self).__init__(meta)
-            self._members = members
-
-        @property
-        def members(self):
-            return self._members
 
 
 class CommunityDestination(Destination):

--- a/dispersy.py
+++ b/dispersy.py
@@ -3116,7 +3116,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                 assert not message.payload.mid == message.community.my_member.mid, "we should always have our own dispersy-identity"
                 logger.warning("could not find any missing members.  no response is sent [%s, mid:%s, cid:%s]", message.payload.mid.encode("HEX"), message.community.my_member.mid.encode("HEX"), message.community.cid.encode("HEX"))
 
-    def create_signature_request(self, community, candidates, message, response_func, response_args=(), timeout=10.0, forward=True):
+    def create_signature_request(self, community, candidate, message, response_func, response_args=(), timeout=10.0, forward=True):
         """
         Create a dispersy-signature-request message.
 
@@ -3144,8 +3144,8 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
          created.
         @type community: Community
 
-        @param candidates: List with destination candidates.
-        @type candidates: [Candidate]
+        @param candidate: Destination candidate.
+        @type candidate: Candidate
 
         @param message: The message that needs the signature.
         @type message: Message.Implementation
@@ -3167,8 +3167,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         if __debug__:
             from .community import Community
         assert isinstance(community, Community)
-        assert isinstance(candidates, list)
-        assert all(isinstance(candidate, Candidate) for candidate in candidates)
+        assert isinstance(candidate, Candidate)
         assert isinstance(message, Message.Implementation)
         assert isinstance(message.authentication, DoubleMemberAuthentication.Implementation)
         assert hasattr(response_func, "__call__")
@@ -3188,7 +3187,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         # message that should obtain more signatures
         meta = community.get_meta_message(u"dispersy-signature-request")
         cache.request = meta.impl(distribution=(community.global_time,),
-                                  destination=tuple(candidates),
+                                  destination=(candidate,),
                                   payload=(identifier, message))
 
         logger.debug("asking %s", [member.mid.encode("HEX") for member in members])

--- a/dispersy.py
+++ b/dispersy.py
@@ -61,7 +61,7 @@ from .bloomfilter import BloomFilter
 from .bootstrap import get_bootstrap_candidates
 from .candidate import BootstrapCandidate, LoopbackCandidate, WalkCandidate, Candidate
 from .crypto import ec_generate_key, ec_to_public_bin, ec_to_private_bin
-from .destination import CommunityDestination, CandidateDestination, MemberDestination
+from .destination import CommunityDestination, CandidateDestination
 from .dispersydatabase import DispersyDatabase
 from .distribution import SyncDistribution, FullSyncDistribution, LastSyncDistribution, DirectDistribution, GlobalTimePruning
 from .member import DummyMember, Member
@@ -529,7 +529,7 @@ class Dispersy(object):
             from .community import Community
         assert isinstance(community, Community)
         messages = [Message(community, u"dispersy-identity", MemberAuthentication(encoding="bin"), PublicResolution(), LastSyncDistribution(synchronization_direction=u"ASC", priority=16, history_size=1), CommunityDestination(node_count=0), IdentityPayload(), self._generic_timeline_check, self.on_identity),
-                    Message(community, u"dispersy-signature-request", NoAuthentication(), PublicResolution(), DirectDistribution(), MemberDestination(), SignatureRequestPayload(), self.check_signature_request, self.on_signature_request),
+                    Message(community, u"dispersy-signature-request", NoAuthentication(), PublicResolution(), DirectDistribution(), CandidateDestination(), SignatureRequestPayload(), self.check_signature_request, self.on_signature_request),
                     Message(community, u"dispersy-signature-response", NoAuthentication(), PublicResolution(), DirectDistribution(), CandidateDestination(), SignatureResponsePayload(), self.check_signature_response, self.on_signature_response),
                     Message(community, u"dispersy-authorize", MemberAuthentication(), PublicResolution(), FullSyncDistribution(enable_sequence_number=True, synchronization_direction=u"ASC", priority=128), CommunityDestination(node_count=10), AuthorizePayload(), self._generic_timeline_check, self.on_authorize),
                     Message(community, u"dispersy-revoke", MemberAuthentication(), PublicResolution(), FullSyncDistribution(enable_sequence_number=True, synchronization_direction=u"ASC", priority=128), CommunityDestination(node_count=10), RevokePayload(), self._generic_timeline_check, self.on_revoke),
@@ -2737,9 +2737,6 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
          - CandidateDestination causes a message to be sent to the addresses in
            message.destination.candidates.
 
-         - MemberDestination causes a message to be sent to the address associated to the member in
-           message.destination.members.
-
          - CommunityDestination causes a message to be sent to one or more addresses to be picked
            from the database candidate table.
 
@@ -2762,18 +2759,6 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         elif isinstance(meta.destination, CandidateDestination):
             # CandidateDestination.candidates may be empty
             result = all(self._send(message.destination.candidates, [message]) for message in messages)
-
-        elif isinstance(meta.destination, MemberDestination):
-            # MemberDestination.candidates may be empty
-            result = all(self._send([candidate
-                                     for candidate
-                                     in message.community.candidates.itervalues()
-                                     if any(candidate.is_associated(message.community, member)
-                                            for member
-                                            in message.destination.members)],
-                                    [message])
-                         for message
-                         in messages)
 
         else:
             raise NotImplementedError(meta.destination)
@@ -3131,7 +3116,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                 assert not message.payload.mid == message.community.my_member.mid, "we should always have our own dispersy-identity"
                 logger.warning("could not find any missing members.  no response is sent [%s, mid:%s, cid:%s]", message.payload.mid.encode("HEX"), message.community.my_member.mid.encode("HEX"), message.community.cid.encode("HEX"))
 
-    def create_signature_request(self, community, message, response_func, response_args=(), timeout=10.0, forward=True):
+    def create_signature_request(self, community, candidates, message, response_func, response_args=(), timeout=10.0, forward=True):
         """
         Create a dispersy-signature-request message.
 
@@ -3159,6 +3144,9 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
          created.
         @type community: Community
 
+        @param candidates: List with destination candidates.
+        @type candidates: [Candidate]
+
         @param message: The message that needs the signature.
         @type message: Message.Implementation
 
@@ -3179,6 +3167,8 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         if __debug__:
             from .community import Community
         assert isinstance(community, Community)
+        assert isinstance(candidates, list)
+        assert all(isinstance(candidate, Candidate) for candidate in candidates)
         assert isinstance(message, Message.Implementation)
         assert isinstance(message.authentication, DoubleMemberAuthentication.Implementation)
         assert hasattr(response_func, "__call__")
@@ -3198,7 +3188,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         # message that should obtain more signatures
         meta = community.get_meta_message(u"dispersy-signature-request")
         cache.request = meta.impl(distribution=(community.global_time,),
-                                  destination=tuple(members),
+                                  destination=tuple(candidates),
                                   payload=(identifier, message))
 
         logger.debug("asking %s", [member.mid.encode("HEX") for member in members])

--- a/message.py
+++ b/message.py
@@ -582,7 +582,7 @@ class Message(MetaObject):
         from .authentication import Authentication, NoAuthentication, MemberAuthentication, DoubleMemberAuthentication
         from .resolution import Resolution, PublicResolution, LinearResolution, DynamicResolution
         from .distribution import Distribution, RelayDistribution, DirectDistribution, FullSyncDistribution, LastSyncDistribution
-        from .destination import Destination, CandidateDestination, MemberDestination, CommunityDestination
+        from .destination import Destination, CandidateDestination, CommunityDestination
 
         assert isinstance(authentication, Authentication)
         assert isinstance(resolution, Resolution)
@@ -596,26 +596,26 @@ class Message(MetaObject):
         if isinstance(authentication, NoAuthentication):
             require(authentication, resolution, PublicResolution)
             require(authentication, distribution, (RelayDistribution, DirectDistribution))
-            require(authentication, destination, (CandidateDestination, MemberDestination, CommunityDestination))
+            require(authentication, destination, (CandidateDestination, CommunityDestination))
         elif isinstance(authentication, MemberAuthentication):
             require(authentication, resolution, (PublicResolution, LinearResolution, DynamicResolution))
             require(authentication, distribution, (RelayDistribution, DirectDistribution, FullSyncDistribution, LastSyncDistribution))
-            require(authentication, destination, (CandidateDestination, MemberDestination, CommunityDestination))
+            require(authentication, destination, (CandidateDestination, CommunityDestination))
         elif isinstance(authentication, DoubleMemberAuthentication):
             require(authentication, resolution, (PublicResolution, LinearResolution, DynamicResolution))
             require(authentication, distribution, (RelayDistribution, DirectDistribution, FullSyncDistribution, LastSyncDistribution))
-            require(authentication, destination, (CandidateDestination, MemberDestination, CommunityDestination))
+            require(authentication, destination, (CandidateDestination, CommunityDestination))
         else:
             raise ValueError("%s is not supported" % authentication.__class_.__name__)
 
         if isinstance(resolution, PublicResolution):
             require(resolution, authentication, (NoAuthentication, MemberAuthentication, DoubleMemberAuthentication))
             require(resolution, distribution, (RelayDistribution, DirectDistribution, FullSyncDistribution, LastSyncDistribution))
-            require(resolution, destination, (CandidateDestination, MemberDestination, CommunityDestination))
+            require(resolution, destination, (CandidateDestination, CommunityDestination))
         elif isinstance(resolution, LinearResolution):
             require(resolution, authentication, (MemberAuthentication, DoubleMemberAuthentication))
             require(resolution, distribution, (RelayDistribution, DirectDistribution, FullSyncDistribution, LastSyncDistribution))
-            require(resolution, destination, (CandidateDestination, MemberDestination, CommunityDestination))
+            require(resolution, destination, (CandidateDestination, CommunityDestination))
         elif isinstance(resolution, DynamicResolution):
             pass
         else:
@@ -624,11 +624,11 @@ class Message(MetaObject):
         if isinstance(distribution, RelayDistribution):
             require(distribution, authentication, (NoAuthentication, MemberAuthentication, DoubleMemberAuthentication))
             require(distribution, resolution, (PublicResolution, LinearResolution, DynamicResolution))
-            require(distribution, destination, (CandidateDestination, MemberDestination))
+            require(distribution, destination, (CandidateDestination,))
         elif isinstance(distribution, DirectDistribution):
             require(distribution, authentication, (NoAuthentication, MemberAuthentication, DoubleMemberAuthentication))
             require(distribution, resolution, (PublicResolution, LinearResolution, DynamicResolution))
-            require(distribution, destination, (CandidateDestination, MemberDestination, CommunityDestination))
+            require(distribution, destination, (CandidateDestination, CommunityDestination))
         elif isinstance(distribution, FullSyncDistribution):
             require(distribution, authentication, (MemberAuthentication, DoubleMemberAuthentication))
             require(distribution, resolution, (PublicResolution, LinearResolution, DynamicResolution))
@@ -643,10 +643,6 @@ class Message(MetaObject):
             raise ValueError("%s is not supported" % distribution.__class_.__name__)
 
         if isinstance(destination, CandidateDestination):
-            require(destination, authentication, (NoAuthentication, MemberAuthentication, DoubleMemberAuthentication))
-            require(destination, resolution, (PublicResolution, LinearResolution, DynamicResolution))
-            require(destination, distribution, (RelayDistribution, DirectDistribution))
-        elif isinstance(destination, MemberDestination):
             require(destination, authentication, (NoAuthentication, MemberAuthentication, DoubleMemberAuthentication))
             require(destination, resolution, (PublicResolution, LinearResolution, DynamicResolution))
             require(destination, distribution, (RelayDistribution, DirectDistribution))

--- a/tests/debugcommunity/community.py
+++ b/tests/debugcommunity/community.py
@@ -5,7 +5,7 @@ from ...authentication import DoubleMemberAuthentication, MemberAuthentication
 from ...candidate import Candidate
 from ...community import Community, HardKilledCommunity
 from ...conversion import DefaultConversion
-from ...destination import CommunityDestination, CandidateDestination
+from ...destination import CommunityDestination
 from ...distribution import DirectDistribution, FullSyncDistribution, LastSyncDistribution, GlobalTimePruning
 from ...message import Message, DelayMessageByProof
 from ...resolution import PublicResolution, LinearResolution, DynamicResolution
@@ -64,7 +64,7 @@ class DebugCommunity(Community):
         return [Message(self, u"last-1-test", MemberAuthentication(), PublicResolution(), LastSyncDistribution(synchronization_direction=u"ASC", priority=128, history_size=1), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
                 Message(self, u"last-9-test", MemberAuthentication(), PublicResolution(), LastSyncDistribution(synchronization_direction=u"ASC", priority=128, history_size=9), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
                 Message(self, u"last-1-doublemember-text", DoubleMemberAuthentication(allow_signature_func=self.allow_signature_func), PublicResolution(), LastSyncDistribution(synchronization_direction=u"ASC", priority=128, history_size=1), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
-                Message(self, u"double-signed-text", DoubleMemberAuthentication(allow_signature_func=self.allow_double_signed_text), PublicResolution(), DirectDistribution(), CandidateDestination(), TextPayload(), self.check_text, self.on_text),
+                Message(self, u"double-signed-text", DoubleMemberAuthentication(allow_signature_func=self.allow_double_signed_text), PublicResolution(), DirectDistribution(), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
                 Message(self, u"full-sync-text", MemberAuthentication(), PublicResolution(), FullSyncDistribution(enable_sequence_number=False, synchronization_direction=u"ASC", priority=128), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text, self.undo_text),
                 Message(self, u"ASC-text", MemberAuthentication(), PublicResolution(), FullSyncDistribution(enable_sequence_number=False, synchronization_direction=u"ASC", priority=128), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
                 Message(self, u"DESC-text", MemberAuthentication(), PublicResolution(), FullSyncDistribution(enable_sequence_number=False, synchronization_direction=u"DESC", priority=128), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
@@ -94,16 +94,13 @@ class DebugCommunity(Community):
     # double-signed-text
     #
 
-    def create_double_signed_text(self, text, candidates, member, response_func, response_args=(), timeout=10.0, forward=True):
-        assert isinstance(candidates, list)
-        assert len(candidates) == 1
-        assert all(isinstance(candidate, Candidate) for candidate in candidates)
+    def create_double_signed_text(self, text, candidate, member, response_func, response_args=(), timeout=10.0, forward=True):
+        assert isinstance(candidate, Candidate)
         meta = self.get_meta_message(u"double-signed-text")
         message = meta.impl(authentication=([self._my_member, member],),
                             distribution=(self.global_time,),
-                            destination=tuple(candidates),
                             payload=(text,))
-        return self.create_dispersy_signature_request(candidates, message, response_func, response_args, timeout, forward)
+        return self.create_dispersy_signature_request(candidate, message, response_func, response_args, timeout, forward)
 
     def allow_double_signed_text(self, message):
         """

--- a/tests/debugcommunity/community.py
+++ b/tests/debugcommunity/community.py
@@ -5,7 +5,7 @@ from ...authentication import DoubleMemberAuthentication, MemberAuthentication
 from ...candidate import Candidate
 from ...community import Community, HardKilledCommunity
 from ...conversion import DefaultConversion
-from ...destination import MemberDestination, CommunityDestination
+from ...destination import CommunityDestination, CandidateDestination
 from ...distribution import DirectDistribution, FullSyncDistribution, LastSyncDistribution, GlobalTimePruning
 from ...message import Message, DelayMessageByProof
 from ...resolution import PublicResolution, LinearResolution, DynamicResolution
@@ -64,7 +64,7 @@ class DebugCommunity(Community):
         return [Message(self, u"last-1-test", MemberAuthentication(), PublicResolution(), LastSyncDistribution(synchronization_direction=u"ASC", priority=128, history_size=1), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
                 Message(self, u"last-9-test", MemberAuthentication(), PublicResolution(), LastSyncDistribution(synchronization_direction=u"ASC", priority=128, history_size=9), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
                 Message(self, u"last-1-doublemember-text", DoubleMemberAuthentication(allow_signature_func=self.allow_signature_func), PublicResolution(), LastSyncDistribution(synchronization_direction=u"ASC", priority=128, history_size=1), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
-                Message(self, u"double-signed-text", DoubleMemberAuthentication(allow_signature_func=self.allow_double_signed_text), PublicResolution(), DirectDistribution(), MemberDestination(), TextPayload(), self.check_text, self.on_text),
+                Message(self, u"double-signed-text", DoubleMemberAuthentication(allow_signature_func=self.allow_double_signed_text), PublicResolution(), DirectDistribution(), CandidateDestination(), TextPayload(), self.check_text, self.on_text),
                 Message(self, u"full-sync-text", MemberAuthentication(), PublicResolution(), FullSyncDistribution(enable_sequence_number=False, synchronization_direction=u"ASC", priority=128), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text, self.undo_text),
                 Message(self, u"ASC-text", MemberAuthentication(), PublicResolution(), FullSyncDistribution(enable_sequence_number=False, synchronization_direction=u"ASC", priority=128), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
                 Message(self, u"DESC-text", MemberAuthentication(), PublicResolution(), FullSyncDistribution(enable_sequence_number=False, synchronization_direction=u"DESC", priority=128), CommunityDestination(node_count=10), TextPayload(), self.check_text, self.on_text),
@@ -94,13 +94,16 @@ class DebugCommunity(Community):
     # double-signed-text
     #
 
-    def create_double_signed_text(self, text, member, response_func, response_args=(), timeout=10.0, forward=True):
+    def create_double_signed_text(self, text, candidates, member, response_func, response_args=(), timeout=10.0, forward=True):
+        assert isinstance(candidates, list)
+        assert len(candidates) == 1
+        assert all(isinstance(candidate, Candidate) for candidate in candidates)
         meta = self.get_meta_message(u"double-signed-text")
         message = meta.impl(authentication=([self._my_member, member],),
                             distribution=(self.global_time,),
-                            destination=(member,),
+                            destination=tuple(candidates),
                             payload=(text,))
-        return self.create_dispersy_signature_request(message, response_func, response_args, timeout, forward)
+        return self.create_dispersy_signature_request(candidates, message, response_func, response_args, timeout, forward)
 
     def allow_double_signed_text(self, message):
         """

--- a/tests/debugcommunity/node.py
+++ b/tests/debugcommunity/node.py
@@ -504,13 +504,12 @@ class DebugNode(object):
                          destination=(destination_candidate,),
                          payload=(missing_member, missing_message, missing_sequence_low, missing_sequence_high))
 
-    def create_dispersy_signature_request(self, message, global_time, destination_member, destination_candidate):
+    def create_dispersy_signature_request(self, message, global_time, destination_candidate):
         """
         Returns a new dispersy-signature-request message.
         """
         assert isinstance(message, Message.Implementation)
         assert isinstance(global_time, (int, long))
-        assert isinstance(destination_member, Member)
         assert isinstance(destination_candidate, Candidate)
         meta = self._community.get_meta_message(u"dispersy-signature-request")
         return meta.impl(distribution=(global_time,),

--- a/tests/debugcommunity/node.py
+++ b/tests/debugcommunity/node.py
@@ -504,16 +504,17 @@ class DebugNode(object):
                          destination=(destination_candidate,),
                          payload=(missing_member, missing_message, missing_sequence_low, missing_sequence_high))
 
-    def create_dispersy_signature_request(self, message, global_time, destination_member):
+    def create_dispersy_signature_request(self, message, global_time, destination_member, destination_candidate):
         """
         Returns a new dispersy-signature-request message.
         """
-        isinstance(message, Message.Implementation)
-        isinstance(global_time, (int, long))
-        isinstance(destination_member, Member)
+        assert isinstance(message, Message.Implementation)
+        assert isinstance(global_time, (int, long))
+        assert isinstance(destination_member, Member)
+        assert isinstance(destination_candidate, Candidate)
         meta = self._community.get_meta_message(u"dispersy-signature-request")
         return meta.impl(distribution=(global_time,),
-                         destination=(destination_member,),
+                         destination=(destination_candidate,),
                          payload=(message,))
 
     def create_dispersy_signature_response(self, identifier, message, global_time, destination_candidate):

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -31,7 +31,7 @@ class TestSignature(DispersyTestClass):
             container["timeout"] += 1
             return False, False, False
 
-        community.create_double_signed_text("Accept=<does not reach this point>", self._dispersy.get_member(node.my_member.public_key), on_response, (), 3.0)
+        community.create_double_signed_text("Accept=<does not reach this point>", [node.candidate], self._dispersy.get_member(node.my_member.public_key), on_response, (), 3.0)
         yield 0.11
 
         logger.debug("NODE receives dispersy-signature-request message")
@@ -74,7 +74,7 @@ class TestSignature(DispersyTestClass):
             self.assertFalse(modified)
             container["response"] += 1
             return False
-        community.create_double_signed_text("Accept=<does not matter>", self._dispersy.get_member(node.my_member.public_key), on_response, (), 3.0)
+        community.create_double_signed_text("Accept=<does not matter>", [node.candidate], self._dispersy.get_member(node.my_member.public_key), on_response, (), 3.0)
         yield 0.11
 
         logger.debug("NODE receives dispersy-signature-request message from SELF")

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -31,7 +31,7 @@ class TestSignature(DispersyTestClass):
             container["timeout"] += 1
             return False, False, False
 
-        community.create_double_signed_text("Accept=<does not reach this point>", [node.candidate], self._dispersy.get_member(node.my_member.public_key), on_response, (), 3.0)
+        community.create_double_signed_text("Accept=<does not reach this point>", node.candidate, self._dispersy.get_member(node.my_member.public_key), on_response, (), 3.0)
         yield 0.11
 
         logger.debug("NODE receives dispersy-signature-request message")
@@ -74,7 +74,7 @@ class TestSignature(DispersyTestClass):
             self.assertFalse(modified)
             container["response"] += 1
             return False
-        community.create_double_signed_text("Accept=<does not matter>", [node.candidate], self._dispersy.get_member(node.my_member.public_key), on_response, (), 3.0)
+        community.create_double_signed_text("Accept=<does not matter>", node.candidate, self._dispersy.get_member(node.my_member.public_key), on_response, (), 3.0)
         yield 0.11
 
         logger.debug("NODE receives dispersy-signature-request message from SELF")


### PR DESCRIPTION
Using MemberDestination can result in messages not being delivered
when the walker did not recently visit the member in question.  Using
CandidateDestination is preferred.

Currently only the signature request uses MemberDestination, we have
rewritten it to use CandidateDestination instead.  Since neither of
these destinations add anything to the binary packet, this change is
fully backwards compatible.
