### PR TITLE
Enable or disable bloom filter sync.

### DIFF
--- a/dispersy.py
+++ b/dispersy.py
@@ -4464,7 +4464,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
             walker_communities.append(community)
 
             actualtime = time()
-            allow_sync = actualtime - community.__most_recent_sync > 4.5
+            allow_sync = community.dispersy_enable_bloom_filter_sync and actualtime - community.__most_recent_sync > 4.5
             logger.debug("previous sync was %.1f seconds ago %s", actualtime - community.__most_recent_sync, "" if allow_sync else "(no sync this cycle)")
             if allow_sync:
                 community.__most_recent_sync = actualtime


### PR DESCRIPTION
When dispersy_enable_bloom_filter_sync is False:
- dispersy_take_step will always be called with allow_sync = False
- acceptable_global_time will return 2 *\* 63 - 1 instead of its
  previous calculation involving current global time, mean
  neighborhood global time, and dispersy_acceptable_global_time_range.
