### PR TITLE
Improvements to unittests

### DIFF
--- a/tests/debugcommunity/node.py
+++ b/tests/debugcommunity/node.py
@@ -677,7 +677,7 @@ class DebugNode(object):
         assert isinstance(policy, (PublicResolution.Implementation, LinearResolution.Implementation))
         return self._create_text(u"dynamic-resolution-text", text, global_time, resolution=(policy,))
 
-    def create_sequence_test(self, text, global_time, sequence_number):
+    def create_sequence_text(self, text, global_time, sequence_number):
         """
         Returns a new sequence-text message.
         """

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -6,10 +6,10 @@ from time import time
 from ..message import Message, BatchConfiguration
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestBatch(DispersyTestClass):
+class TestBatch(DispersyTestFunc):
 
     def __init__(self, *args, **kargs):
         super(TestBatch, self).__init__(*args, **kargs)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -11,10 +11,10 @@ from ..candidate import BootstrapCandidate
 from ..message import Message, DropMessage
 from .debugcommunity.community import DebugCommunity
 
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestBootstrapServers(DispersyTestClass):
+class TestBootstrapServers(DispersyTestFunc):
 
     @skipUnless(environ.get("TEST_BOOTSTRAP") == "yes", "This 'unittest' tests the external bootstrap processes, as such, this is not part of the code review process")
     @call_on_dispersy_thread

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,7 +1,7 @@
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestCallback(DispersyTestClass):
+class TestCallback(DispersyTestFunc):
 
     def previous_performance_profile(self):
         """

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -1,16 +1,15 @@
 import logging
 logger = logging.getLogger(__name__)
 
-from unittest import skip
 from fractions import gcd
 from itertools import combinations, islice
 from time import time
+from unittest import skip
 
 from ..candidate import CANDIDATE_ELIGIBLE_DELAY
 from ..tool.tracker import TrackerCommunity
 from .debugcommunity.community import DebugCommunity
 from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
-from ..candidate import CANDIDATE_ELIGIBLE_DELAY
 
 class NoBootstrapDebugCommunity(DebugCommunity):
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -7,10 +7,10 @@ import unittest
 
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestClassification(DispersyTestClass):
+class TestClassification(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_reclassify_unloaded_community(self):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,9 +1,9 @@
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestCrypto(DispersyTestClass):
+class TestCrypto(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_invalid_public_key(self):

--- a/tests/test_destroycommunity.py
+++ b/tests/test_destroycommunity.py
@@ -1,9 +1,9 @@
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestDestroyCommunity(DispersyTestClass):
+class TestDestroyCommunity(DispersyTestFunc):
     # TODO: test that after a hard-kill, all new incoming messages are dropped.
     # TODO: test that after a hard-kill, nothing is added to the candidate table anymore
 

--- a/tests/test_dynamicsettings.py
+++ b/tests/test_dynamicsettings.py
@@ -4,10 +4,10 @@ logger = logging.getLogger(__name__)
 from ..resolution import PublicResolution, LinearResolution
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestDynamicSettings(DispersyTestClass):
+class TestDynamicSettings(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_default_resolution(self):

--- a/tests/test_identitalpayload.py
+++ b/tests/test_identitalpayload.py
@@ -1,9 +1,9 @@
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestIdenticalPayload(DispersyTestClass):
+class TestIdenticalPayload(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_incoming__drop_first(self):

--- a/tests/test_member.py
+++ b/tests/test_member.py
@@ -1,9 +1,9 @@
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestMemberTag(DispersyTestClass):
+class TestMemberTag(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_ignore_test(self):

--- a/tests/test_missingmessage.py
+++ b/tests/test_missingmessage.py
@@ -5,10 +5,10 @@ from random import shuffle
 
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestMissingMessage(DispersyTestClass):
+class TestMissingMessage(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_single_request(self):

--- a/tests/test_neighborhood.py
+++ b/tests/test_neighborhood.py
@@ -1,9 +1,9 @@
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestNeighborhood(DispersyTestClass):
+class TestNeighborhood(DispersyTestFunc):
 
     def test_forward_1(self):
         return self.forward(1)

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -4,7 +4,6 @@ summary = logging.getLogger("test-overlay-summary")
 
 from os import environ
 from pprint import pformat
-from itertools import chain
 from time import time
 from unittest import skipUnless
 from collections import defaultdict
@@ -61,10 +60,7 @@ class TestOverlay(DispersyTestFunc):
                     now = time()
 
                     # count -everyone- that is active (i.e. walk or stumble)
-                    active_canidates = [candidate
-                                        for candidate
-                                        in self._candidates.itervalues()
-                                        if candidate.is_active(self, now)]
+                    active_canidates = list(self.dispersy_yield_verified_candidates())
                     if len(active_canidates) > 20:
                         logger.debug("there are %d active non-bootstrap candidates available, prematurely quitting fast walker", len(active_canidates))
                         break
@@ -72,7 +68,7 @@ class TestOverlay(DispersyTestFunc):
                     # request bootstrap peers that are eligible
                     eligible_candidates = [candidate
                                            for candidate
-                                           in chain(self._dispersy.bootstrap_candidates)
+                                           in self._dispersy.bootstrap_candidates
                                            if candidate.is_eligible_for_walk(now)]
                     for count, candidate in enumerate(eligible_candidates[:len(eligible_candidates) / 2], 1):
                         logger.debug("%d/%d extra walk to %s", count, len(eligible_candidates), candidate)

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -3,10 +3,10 @@ logger = logging.getLogger(__name__)
 
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestPruning(DispersyTestClass):
+class TestPruning(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_local_creation_causes_pruning(self):

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -2,10 +2,10 @@ from collections import defaultdict
 
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestSequence(DispersyTestClass):
+class TestSequence(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def incoming_simple_conflict_different_global_time(self):
@@ -322,39 +322,37 @@ class TestSequence(DispersyTestClass):
     def test_requests_3_24(self):
         self.requests(3, [], (11, 11), (11, 50), (100, 200))
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         """
         SELF generates messages with sequence [1:MESSAGE_COUNT].
         """
         def on_dispersy_thread():
-            cls._community = DebugCommunity.create_community(cls._dispersy, cls._my_member)
-            cls._nodes = [DebugNode(cls._community) for _ in xrange(3)]
-            for node in cls._nodes:
+            self._community = DebugCommunity.create_community(self._dispersy, self._my_member)
+            self._nodes = [DebugNode(self._community) for _ in xrange(3)]
+            for node in self._nodes:
                 node.init_socket()
                 node.init_my_member()
 
             # create messages
-            cls._messages = []
+            self._messages = []
             for i in xrange(1, 11):
-                message = cls._community.create_sequence_text("Sequence message #%d" % i)
+                message = self._community.create_sequence_text("Sequence message #%d" % i)
                 assert message.distribution.sequence_number == i
-                cls._messages.append(message)
+                self._messages.append(message)
 
-        super(TestSequence, cls).setUpClass()
-        cls._dispersy.callback.call(on_dispersy_thread)
+        super(TestSequence, self).setUp()
+        self._dispersy.callback.call(on_dispersy_thread)
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         """
         Cleanup.
         """
         def on_dispersy_thread():
-            cls._community.create_dispersy_destroy_community(u"hard-kill")
-            cls._dispersy.get_community(cls._community.cid).unload_community()
+            self._community.create_dispersy_destroy_community(u"hard-kill")
+            self._dispersy.get_community(self._community.cid).unload_community()
 
-        cls._dispersy.callback.call(on_dispersy_thread)
-        super(TestSequence, cls).tearDownClass()
+        self._dispersy.callback.call(on_dispersy_thread)
+        super(TestSequence, self).tearDown()
 
     @call_on_dispersy_thread
     def requests(self, node_count, responses, *pairs):

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -30,7 +30,7 @@ class TestSequence(DispersyTestFunc):
         msgs = defaultdict(dict)
         for i in xrange(1, 10):
             for j in xrange(1, 10):
-                msgs[i][j] = node.create_sequence_test("M@%d#%d" % (i, j), i, j)
+                msgs[i][j] = node.create_sequence_text("M@%d#%d" % (i, j), i, j)
 
         community.delete_messages(meta.name)
         # SELF must accept M@6#1
@@ -342,17 +342,6 @@ class TestSequence(DispersyTestFunc):
 
         super(TestSequence, self).setUp()
         self._dispersy.callback.call(on_dispersy_thread)
-
-    def tearDown(self):
-        """
-        Cleanup.
-        """
-        def on_dispersy_thread():
-            self._community.create_dispersy_destroy_community(u"hard-kill")
-            self._dispersy.get_community(self._community.cid).unload_community()
-
-        self._dispersy.callback.call(on_dispersy_thread)
-        super(TestSequence, self).tearDown()
 
     @call_on_dispersy_thread
     def requests(self, node_count, responses, *pairs):

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -4,10 +4,10 @@ logger = logging.getLogger(__name__)
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
 
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestSignature(DispersyTestClass):
+class TestSignature(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_no_response_from_node(self):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,10 +5,10 @@ import socket
 
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestSync(DispersyTestClass):
+class TestSync(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_modulo(self):

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -4,10 +4,10 @@ logger = logging.getLogger(__name__)
 from ..message import DelayMessageByProof
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestTimeline(DispersyTestClass):
+class TestTimeline(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_succeed_check(self):

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -4,10 +4,10 @@ logger = logging.getLogger(__name__)
 from ..message import Message
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
-from .dispersytestclass import DispersyTestClass, call_on_dispersy_thread
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestUndo(DispersyTestClass):
+class TestUndo(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def test_self_undo_own(self):

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -1,46 +1,57 @@
-from unittest import expectedFailure
 import logging
 logger = logging.getLogger(__name__)
 
 from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
-class TestUnittestFunc(DispersyTestFunc):
+def failure_to_success(exception_class, exception_message):
+    def helper1(func):
+        def helper2(*args, **kargs):
+            try:
+                func(*args, **kargs)
+            except Exception as exception:
+                if isinstance(exception, exception_class) and exception.message == exception_message:
+                    return
+
+                # if isinstance(exception, KeyError) and exception.message == "This must fail":
+                #     return
+
+                # if isinstance(exception, AssertionError) and exception.message == "This must fail":
+                #     return
+
+                # not one of the pre-programmed exceptions, test should indicate failure
+                raise
+
+        helper2.__name__ = func.__name__
+        return helper2
+    return helper1
+
+class TestUnittest(DispersyTestFunc):
     """
     Tests ensuring that an exception anywhere in _dispersy.callback is propagated to the unittest framework.
     """
 
-    def addExpectedFailure(self, test, err):
-        if isinstance(err, KeyError) and err.message == "This must fail":
-            return super(TestUnittestFunc, self).addExpectedFailure(test, err)
-
-        if isinstance(err, AssertionError) and err.message == "This must fail":
-            return super(TestUnittestFunc, self).addExpectedFailure(test, err)
-
-        # unexpected error
-        return super(TestUnittestFunc, self).addError(test, err)
-
-    @expectedFailure
+    @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
     def test_assert(self):
         " Trivial assert. "
-        assert False, "This must fail"
+        self.assertTrue(False, "This must fail")
 
-    @expectedFailure
+    @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
     def test_KeyError(self):
         " Trivial KeyError. "
         raise KeyError("This must fail")
 
-    @expectedFailure
+    @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
     def test_assert_callback(self):
         " Assert within a registered task. "
         def task():
-            assert False, "This must fail"
+            self.assertTrue(False, "This must fail")
         self._dispersy.callback.register(task)
         yield 10.0
 
-    @expectedFailure
+    @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
     def test_KeyError_callback(self):
         " KeyError within a registered task. "
@@ -49,18 +60,18 @@ class TestUnittestFunc(DispersyTestFunc):
         self._dispersy.callback.register(task)
         yield 10.0
 
-    @expectedFailure
+    @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
     def test_assert_callback_generator(self):
         " Assert within a registered generator task. "
         def task():
             yield 0.1
             yield 0.1
-            assert False, "This must fail"
+            self.assertTrue(False, "This must fail")
         self._dispersy.callback.register(task)
         yield 10.0
 
-    @expectedFailure
+    @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
     def test_KeyError_callback_generator(self):
         " KeyError within a registered generator task. "
@@ -71,16 +82,16 @@ class TestUnittestFunc(DispersyTestFunc):
         self._dispersy.callback.register(task)
         yield 10.0
 
-    @expectedFailure
+    @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
     def test_assert_callback_call(self):
         " Assert within a 'call' task. "
         def task():
-            assert False, "This must fail"
+            self.assertTrue(False, "This must fail")
         self._dispersy.callback.call(task)
         yield 10.0
 
-    @expectedFailure
+    @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
     def test_KeyError_callback_call(self):
         " KeyError within a 'call' task. "
@@ -89,18 +100,18 @@ class TestUnittestFunc(DispersyTestFunc):
         self._dispersy.callback.call(task)
         yield 10.0
 
-    @expectedFailure
+    @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
     def test_assert_callback_call_generator(self):
         " Assert within a 'call' generator task. "
         def task():
             yield 0.1
             yield 0.1
-            assert False, "This must fail"
+            self.assertTrue(False, "This must fail")
         self._dispersy.callback.call(task)
         yield 10.0
 
-    @expectedFailure
+    @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
     def test_KeyError_callback_call_generator(self):
         " KeyError within a 'call' generator task. "

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -1,0 +1,112 @@
+from unittest import expectedFailure
+import logging
+logger = logging.getLogger(__name__)
+
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
+
+class TestUnittestFunc(DispersyTestFunc):
+    """
+    Tests ensuring that an exception anywhere in _dispersy.callback is propagated to the unittest framework.
+    """
+
+    def addExpectedFailure(self, test, err):
+        if isinstance(err, KeyError) and err.message == "This must fail":
+            return super(TestUnittestFunc, self).addExpectedFailure(test, err)
+
+        if isinstance(err, AssertionError) and err.message == "This must fail":
+            return super(TestUnittestFunc, self).addExpectedFailure(test, err)
+
+        # unexpected error
+        return super(TestUnittestFunc, self).addError(test, err)
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_assert(self):
+        " Trivial assert. "
+        assert False, "This must fail"
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_KeyError(self):
+        " Trivial KeyError. "
+        raise KeyError("This must fail")
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_assert_callback(self):
+        " Assert within a registered task. "
+        def task():
+            assert False, "This must fail"
+        self._dispersy.callback.register(task)
+        yield 10.0
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_KeyError_callback(self):
+        " KeyError within a registered task. "
+        def task():
+            raise KeyError("This must fail")
+        self._dispersy.callback.register(task)
+        yield 10.0
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_assert_callback_generator(self):
+        " Assert within a registered generator task. "
+        def task():
+            yield 0.1
+            yield 0.1
+            assert False, "This must fail"
+        self._dispersy.callback.register(task)
+        yield 10.0
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_KeyError_callback_generator(self):
+        " KeyError within a registered generator task. "
+        def task():
+            yield 0.1
+            yield 0.1
+            raise KeyError("This must fail")
+        self._dispersy.callback.register(task)
+        yield 10.0
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_assert_callback_call(self):
+        " Assert within a 'call' task. "
+        def task():
+            assert False, "This must fail"
+        self._dispersy.callback.call(task)
+        yield 10.0
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_KeyError_callback_call(self):
+        " KeyError within a 'call' task. "
+        def task():
+            raise KeyError("This must fail")
+        self._dispersy.callback.call(task)
+        yield 10.0
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_assert_callback_call_generator(self):
+        " Assert within a 'call' generator task. "
+        def task():
+            yield 0.1
+            yield 0.1
+            assert False, "This must fail"
+        self._dispersy.callback.call(task)
+        yield 10.0
+
+    @expectedFailure
+    @call_on_dispersy_thread
+    def test_KeyError_callback_call_generator(self):
+        " KeyError within a 'call' generator task. "
+        def task():
+            yield 0.1
+            yield 0.1
+            raise KeyError("This must fail")
+        self._dispersy.callback.call(task)
+        yield 10.0

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -12,12 +12,6 @@ def failure_to_success(exception_class, exception_message):
                 if isinstance(exception, exception_class) and exception.message == exception_message:
                     return
 
-                # if isinstance(exception, KeyError) and exception.message == "This must fail":
-                #     return
-
-                # if isinstance(exception, AssertionError) and exception.message == "This must fail":
-                #     return
-
                 # not one of the pre-programmed exceptions, test should indicate failure
                 raise
 


### PR DESCRIPTION
- fix to callback, will keep nose from hanging when an exception occurs.
- fix to the experimental fast walker implementation in test_overlay.py.
- removed DispersyTestClass, didn't work with non-unittest exceptions occurring.  Use DispersyTestFunc instead.
- new test_unittest.py ensuring that failures are propagated to the unittest framework.
