### PR TITLE
RequestCache cleanup.

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -228,6 +228,8 @@ class WalkCandidate(Candidate):
         Returns the category (u"walk", u"stumble", u"intro", or u"none") depending on the current
         time NOW.
         """
+        assert isinstance(now, float), type(now)
+
         if self._last_walk + self._timeout_adjustment <= now < self._last_walk + CANDIDATE_WALK_LIFETIME:
             return u"walk"
 
@@ -243,6 +245,8 @@ class WalkCandidate(Candidate):
         """
         Called when we are about to send an introduction-request to this candidate.
         """
+        assert isinstance(now, float), type(now)
+        assert isinstance(timeout_adjustment, float), type(timeout_adjustment)
         self._last_walk = now
         self._timeout_adjustment = timeout_adjustment
 
@@ -256,12 +260,14 @@ class WalkCandidate(Candidate):
         """
         Called when we receive an introduction-request from this candidate.
         """
+        assert isinstance(now, float), type(now)
         self._last_stumble = now
 
     def intro(self, now):
         """
         Called when we receive an introduction-response introducing this candidate.
         """
+        assert isinstance(now, float), type(now)
         self._last_intro = now
 
     def update(self, tunnel, lan_address, wan_address, connection_type):

--- a/dispersy.py
+++ b/dispersy.py
@@ -77,7 +77,7 @@ from .payload import IntroductionRequestPayload, IntroductionResponsePayload, Pu
 from .payload import MissingMessagePayload, MissingLastMessagePayload
 from .payload import MissingSequencePayload, MissingProofPayload
 from .payload import SignatureRequestPayload, SignatureResponsePayload
-from .requestcache import Cache, RequestCache
+from .requestcache import Cache, NumberCache
 from .resolution import PublicResolution, LinearResolution
 from .statistics import DispersyStatistics
 
@@ -89,10 +89,14 @@ if __debug__:
 CANDIDATE_WALKER_CALLBACK_ID = u"dispersy-candidate-walker"
 
 
-class SignatureRequestCache(Cache):
-    cleanup_delay = 0.0
+class SignatureRequestCache(NumberCache):
 
-    def __init__(self, members, response_func, response_args, timeout):
+    @staticmethod
+    def create_identifier(number):
+        return u"request-cache:signature-request:%d" % (number,)
+
+    def __init__(self, request_cache, members, response_func, response_args, timeout):
+        super(SignatureRequestCache, self).__init__(request_cache)
         self.request = None
         # MEMBERS is a list containing all the members that should add their signature.  currently
         # we only support double signed messages, hence MEMBERS contains only a single Member
@@ -100,21 +104,39 @@ class SignatureRequestCache(Cache):
         self.members = members
         self.response_func = response_func
         self.response_args = response_args
-        self.timeout_delay = timeout
+        self._timeout_delay = timeout
+
+    @property
+    def timeout_delay(self):
+        return self._timeout_delay
+
+    @property
+    def cleanup_delay(self):
+        return 0.0
 
     def on_timeout(self):
         logger.debug("signature timeout")
         self.response_func(self, None, True, *self.response_args)
 
 
-class IntroductionRequestCache(Cache):
-    # we will accept the response at most 10.5 seconds after our request
-    timeout_delay = 10.5
-    # the cache remains available at most 4.5 after receiving the response.  this gives some time to
-    # receive the puncture message
-    cleanup_delay = 4.5
+class IntroductionRequestCache(NumberCache):
+    @staticmethod
+    def create_identifier(number):
+        return u"request-cache:introduction-request:%d" % (number,)
+
+    @property
+    def timeout_delay(self):
+        # we will accept the response at most 10.5 seconds after our request
+        return 10.5
+
+    @property
+    def cleanup_delay(self):
+        # the cache remains available at most 4.5 after receiving the response.  this gives some time to receive the
+        # puncture message
+        return 4.5
 
     def __init__(self, community, helper_candidate):
+        super(IntroductionRequestCache, self).__init__(community.request_cache)
         self.community = community
         self.helper_candidate = helper_candidate
         self.response_candidate = None
@@ -133,61 +155,62 @@ class IntroductionRequestCache(Cache):
 
 
 class MissingSomethingCache(Cache):
-    cleanup_delay = 0.0
 
-    def __init__(self, timeout):
-        logger.debug("%s: waiting for %f seconds", self.__class__.__name__, timeout)
-        self.timeout_delay = timeout
+    def __init__(self, timeout, *create_identifier_args):
+        super(MissingSomethingCache, self).__init__(self.create_identifier(*create_identifier_args))
+        logger.debug("%s: waiting for %.1f seconds", self.__class__.__name__, timeout)
+        self._timeout_delay = timeout
         self.callbacks = []
+
+    @property
+    def timeout_delay(self):
+        return self._timeout_delay
+
+    @property
+    def cleanup_delay(self):
+        return 0.0
 
     def on_timeout(self):
         logger.debug("%s: timeout on %d callbacks", self.__class__.__name__, len(self.callbacks))
         for func, args in self.callbacks:
             func(None, *args)
 
-    @staticmethod
-    def properties_to_identifier(*args):
-        raise NotImplementedError()
-
-    @staticmethod
-    def message_to_identifier(message):
-        raise NotImplementedError()
-
 
 class MissingMemberCache(MissingSomethingCache):
 
     @staticmethod
-    def properties_to_identifier(community, member):
-        return "-missing-member-%s-%s-" % (community.cid, member.mid)
-
-    @staticmethod
-    def message_to_identifier(message):
-        return "-missing-member-%s-%s-" % (message.community.cid, message.authentication.member.mid)
+    def create_identifier(member):
+        assert isinstance(member, DummyMember), type(member)
+        return u"request-cache:missing-member:%s" % (member.mid.encode("HEX"),)
 
 
 class MissingMessageCache(MissingSomethingCache):
 
     @staticmethod
-    def properties_to_identifier(community, member, global_time):
-        return "-missing-message-%s-%s-%d-" % (community.cid, member.mid, global_time)
-
-    @staticmethod
-    def message_to_identifier(message):
-        return "-missing-message-%s-%s-%d-" % (message.community.cid, message.authentication.member.mid, message.distribution.global_time)
+    def create_identifier(member, global_time):
+        assert isinstance(member, DummyMember), type(member)
+        assert isinstance(global_time, (int, long)), type(global_time)
+        return u"request-cache:missing-message:%s:%d" % (member.mid.encode("HEX"), global_time)
 
 
 class MissingLastMessageCache(MissingSomethingCache):
 
     @staticmethod
-    def properties_to_identifier(community, member, message):
-        return "-missing-last-message-%s-%s-%s-" % (community.cid, member.mid, message.name.encode("UTF-8"))
-
-    @staticmethod
-    def message_to_identifier(message):
-        return "-missing-last-message-%s-%s-%s-" % (message.community.cid, message.authentication.member.mid, message.name.encode("UTF-8"))
+    def create_identifier(member, message):
+        assert isinstance(member, DummyMember), type(member)
+        assert isinstance(message, (Message, Message.Implementation)), type(message)
+        return u"request-cache:missing-last-message:%s:%s" % (member.mid.encode("HEX"), message.name.encode("UTF-8"))
 
 
 class MissingProofCache(MissingSomethingCache):
+
+    @staticmethod
+    def create_identifier():
+        return u"request-cache:missing-proof"
+
+    @classmethod
+    def create_identifier_from_message(cls, message):
+        return cls.create_identifier()
 
     def __init__(self, timeout):
         super(MissingProofCache, self).__init__(timeout)
@@ -196,39 +219,44 @@ class MissingProofCache(MissingSomethingCache):
         # proof, this allows us send fewer duplicate requests
         self.duplicates = []
 
-    @staticmethod
-    def properties_to_identifier(community):
-        return "-missing-proof-%s-" % (community.cid,)
-
-    @staticmethod
-    def message_to_identifier(message):
-        return "-missing-proof-%s-" % (message.community.cid,)
-
 
 class MissingSequenceOverviewCache(Cache):
-    cleanup_delay = 0.0
 
-    def __init__(self, timeout):
-        self.timeout_delay = timeout
+    @staticmethod
+    def create_identifier(member, message):
+        assert isinstance(member, Member), type(member)
+        assert isinstance(message, (Message, Message.Implementation)), type(message)
+        return u"request-cache:missing-sequence-overview:%s:%s" % (member.mid.encode("HEX"), message.name.encode("UTF-8"))
+
+    def __init__(self, timeout, *create_identifier_args):
+        super(MissingSequenceOverviewCache, self).__init__(self.create_identifier(*create_identifier_args))
+        self._timeout_delay = timeout
         self.missing_high = 0
+
+    @property
+    def timeout_delay(self):
+        return self._timeout_delay
+
+    @property
+    def cleanup_delay(self):
+        return 0.0
 
     def on_timeout(self):
         pass
-
-    @staticmethod
-    def properties_to_identifier(community, member, message):
-        return "-missing-sequence-overview-%s-%s-%s-" % (community.cid, member.mid, message.name.encode("UTF-8"))
 
 
 class MissingSequenceCache(MissingSomethingCache):
 
     @staticmethod
-    def properties_to_identifier(community, member, message, missing_high):
-        return "-missing-sequence-%s-%s-%s-%d-" % (community.cid, member.mid, message.name.encode("UTF-8"), missing_high)
+    def create_identifier(member, message, missing_global_time_high):
+        assert isinstance(member, Member), type(member)
+        assert isinstance(message, (Message, Message.Implementation)), type(message)
+        assert isinstance(missing_global_time_high, (int, long)), type(missing_global_time_high)
+        return u"request-cache:missing-sequence:%s:%s:%d" % (member.mid.encode("HEX"), message.name.encode("UTF-8"), missing_global_time_high)
 
-    @staticmethod
-    def message_to_identifier(message):
-        return "-missing-sequence-%s-%s-%s-%d-" % (message.community.cid, message.authentication.member.mid, message.name.encode("UTF-8"), message.distribution.sequence_number)
+    @classmethod
+    def create_identifier_from_message(cls, message):
+        return cls.create_identifier(message.authentication.member, message, message.distribution.sequence_number)
 
 
 class Dispersy(object):
@@ -282,9 +310,6 @@ class Dispersy(object):
                 os.makedirs(database_directory)
             database_filename = os.path.join(database_directory, database_filename)
         self._database = DispersyDatabase(database_filename)
-
-        # assigns temporary cache objects to unique identifiers
-        self._request_cache = RequestCache(self._callback)
 
         # indicates what our connection type is.  currently it can be u"unknown", u"public", or
         # u"symmetric-NAT"
@@ -486,15 +511,6 @@ class Dispersy(object):
         @rtype: DispersyDatabase
         """
         return self._database
-
-    @property
-    def request_cache(self):
-        """
-        The request cache instance responsible for maintaining identifiers and timeouts for
-        outstanding requests.
-        @rtype: RequestCache
-        """
-        return self._request_cache
 
     @property
     def statistics(self):
@@ -2169,26 +2185,12 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
                 logger.debug("%s %s no candidate to take step", community.cid.encode("HEX"), community.get_classification())
                 return False
 
-    def handle_missing_messages(self, messages, *classes):
-        assert all(isinstance(message, Message.Implementation) for message in messages)
-        assert all(issubclass(cls, MissingSomethingCache) for cls in classes)
-        for message in messages:
-            for cls in classes:
-                cache = self._request_cache.pop(cls.message_to_identifier(message), cls)
-                if cache:
-                    logger.debug("found request cache for %s", message)
-                    for response_func, response_args in cache.callbacks:
-                        response_func(message, *response_args)
-
     def create_introduction_request(self, community, destination, allow_sync, forward=True):
         assert isinstance(destination, WalkCandidate), [type(destination), destination]
 
-        cache = IntroductionRequestCache(community, destination)
+        cache = community.request_cache.add(IntroductionRequestCache(community, destination))
         destination.walk(time(), cache.timeout_delay)
         community.add_candidate(destination)
-
-        # temporary cache object
-        identifier = self._request_cache.claim(cache)
 
         # decide if the requested node should introduce us to someone else
         # advice = random() < 0.5 or len(community.candidates) <= 5
@@ -2257,7 +2259,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         request = meta_request.impl(authentication=(community.my_member,),
                                     distribution=(community.global_time,),
                                     destination=(destination,),
-                                    payload=(destination.get_destination_address(self._wan_address), self._lan_address, self._wan_address, advice, self._connection_type, sync, identifier))
+                                    payload=(destination.get_destination_address(self._wan_address), self._lan_address, self._wan_address, advice, self._connection_type, sync, cache.number))
 
         if forward:
             if sync:
@@ -2281,6 +2283,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         """
         We received a dispersy-introduction-request message.
         """
+        community = messages[0].community
         for message in messages:
             # 25/01/12 Boudewijn: during all DAS2 NAT node314 often sends requests to herself.  This
             # results in more candidates (all pointing to herself) being added to the candidate
@@ -2290,9 +2293,10 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
             # to each other is relatively small.
             # 30/10/12 Niels: additionally check if both our lan_addresses are the same. They should
             # be if we're sending it to ourself. Not checking wan_address as that is subject to change.
-            if self._request_cache.has(message.payload.identifier, IntroductionRequestCache) and self._lan_address == message.payload.source_lan_address:
+            if community.request_cache.has(IntroductionRequestCache.create_identifier(message.payload.identifier)) and \
+                    self._lan_address == message.payload.source_lan_address:
                 logger.debug("dropping dispersy-introduction-request, this identifier is already in use.")
-                yield DropMessage(message, "Duplicate identifier from %s (most likely received from ourself)" % str(message.candidate))
+                yield DropMessage(message, "Duplicate identifier from %s (most likely received from our self)" % str(message.candidate))
                 continue
 
             logger.debug("accepting dispersy-introduction-request from %s", message.candidate)
@@ -2431,8 +2435,9 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                     self._endpoint.send([message.candidate], packets)
 
     def check_introduction_response(self, messages):
+        community = messages[0].community
         for message in messages:
-            if not self._request_cache.has(message.payload.identifier, IntroductionRequestCache):
+            if not community.request_cache.has(IntroductionRequestCache.create_identifier(message.payload.identifier)):
                 self._statistics.walk_invalid_response_identifier += 1
                 yield DropMessage(message, "invalid response identifier")
                 continue
@@ -2499,7 +2504,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
             self._statistics.dict_inc(self._statistics.incoming_introduction_response, candidate.sock_addr)
 
             # get cache object linked to this request and stop timeout from occurring
-            cache = self._request_cache.pop(payload.identifier, IntroductionRequestCache)
+            cache = community.request_cache.pop(IntroductionRequestCache.create_identifier(message.payload.identifier))
 
             # handle the introduction
             lan_introduction_address = payload.lan_introduction_address
@@ -2599,8 +2604,9 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         self._forward(punctures)
 
     def check_puncture(self, messages):
+        community = messages[0].community
         for message in messages:
-            if not self._request_cache.has(message.payload.identifier, IntroductionRequestCache):
+            if not community.request_cache.has(IntroductionRequestCache.create_identifier(message.payload.identifier)):
                 yield DropMessage(message, "invalid response identifier")
                 continue
 
@@ -2612,7 +2618,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
 
         for message in messages:
             # get cache object linked to this request but does NOT stop timeout from occurring
-            cache = self._request_cache.get(message.payload.identifier, IntroductionRequestCache)
+            cache = community.request_cache.get(IntroductionRequestCache.create_identifier(message.payload.identifier))
 
             # when the sender is behind a symmetric NAT and we are not, we will not be able to get
             # through using the port that the helper node gave us (symmetric NAT will give a
@@ -2882,12 +2888,10 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
 
         sendRequest = False
 
-        identifier = MissingMessageCache.properties_to_identifier(community, member, global_time)
-        cache = self._request_cache.get(identifier, MissingMessageCache)
+        cache = community.request_cache.get(MissingMessageCache.create_identifier(member, global_time))
         if not cache:
-            logger.debug("%s", identifier)
-            cache = MissingMessageCache(timeout)
-            self._request_cache.set(identifier, cache)
+            cache = community.request_cache.add(MissingMessageCache(timeout, member, global_time))
+            logger.debug("new cache: %s", cache)
 
             meta = community.get_meta_message(u"dispersy-missing-message")
             request = meta.impl(distribution=(community.global_time,), destination=(candidate,), payload=(member, [global_time]))
@@ -2936,11 +2940,10 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
 
         sendRequest = False
 
-        identifier = MissingLastMessageCache.properties_to_identifier(community, member, message)
-        cache = self._request_cache.get(identifier, MissingLastMessageCache)
+        cache = community.request_cache.get(MissingLastMessageCache.create_identifier(member, message))
         if not cache:
-            cache = MissingLastMessageCache(timeout)
-            self._request_cache.set(identifier, cache)
+            cache = community.request_cache.add(MissingLastMessageCache(timeout, member, message))
+            logger.debug("new cache: %s", cache)
 
             meta = community.get_meta_message(u"dispersy-missing-last-message")
             request = meta.impl(distribution=(community.global_time,), destination=(candidate,), payload=(member, message, count_))
@@ -3044,10 +3047,10 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         """
         We received a dispersy-identity message.
         """
+        community = messages[0].community
         for message in messages:
             # get cache object linked to this request and stop timeout from occurring
-            identifier = MissingMemberCache.message_to_identifier(message)
-            cache = self._request_cache.pop(identifier, MissingMemberCache)
+            cache = community.request_cache.pop(MissingMemberCache.create_identifier(message.authentication.member))
             if cache:
                 for func, args in cache.callbacks:
                     func(message, *args)
@@ -3074,13 +3077,11 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
 
         sendRequest = False
 
-        identifier = MissingMemberCache.properties_to_identifier(community, dummy_member)
-        cache = self._request_cache.get(identifier, MissingMemberCache)
+        cache = community.request_cache.get(MissingMemberCache.create_identifier(dummy_member))
         if not cache:
-            cache = MissingMemberCache(timeout)
-            self._request_cache.set(identifier, cache)
+            cache = community.request_cache.add(MissingMemberCache(timeout, dummy_member))
+            logger.debug("new cache: %s", cache)
 
-            logger.debug("%s sending missing-identity %s", candidate, dummy_member.mid.encode("HEX"))
             meta = community.get_meta_message(u"dispersy-missing-identity")
             request = meta.impl(distribution=(community.global_time,), destination=(candidate,), payload=(dummy_member.mid,))
             self._forward([request])
@@ -3180,15 +3181,15 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         assert len(members) == 1
 
         # temporary cache object
-        cache = SignatureRequestCache(members, response_func, response_args, timeout)
-        identifier = self._request_cache.claim(cache)
+        cache = community.request_cache.add(SignatureRequestCache(community.request_cache, members, response_func, response_args, timeout))
+        logger.debug("new cache: %s", cache)
 
         # the dispersy-signature-request message that will hold the
         # message that should obtain more signatures
         meta = community.get_meta_message(u"dispersy-signature-request")
         cache.request = meta.impl(distribution=(community.global_time,),
                                   destination=(candidate,),
-                                  payload=(identifier, message))
+                                  payload=(cache.number, message))
 
         logger.debug("asking %s", [member.mid.encode("HEX") for member in members])
         self._forward([cache.request])
@@ -3276,15 +3277,16 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
 
     def check_signature_response(self, messages):
         unique = set()
+        community = messages[0].community
 
         for message in messages:
-            if message.payload.identifier in unique:
-                yield DropMessage(message, "duplicate identifier in batch")
-                continue
-
-            cache = self._request_cache.get(message.payload.identifier, SignatureRequestCache)
+            cache = community.request_cache.get(SignatureRequestCache.create_identifier(message.payload.identifier))
             if not cache:
                 yield DropMessage(message, "invalid response identifier")
+                continue
+
+            if cache.identifier in unique:
+                yield DropMessage(message, "duplicate identifier in batch")
                 continue
 
             old_submsg = cache.request.payload.message
@@ -3302,7 +3304,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                 yield DropMessage(message, "global time may not change")
                 continue
 
-            unique.add(message.payload.identifier)
+            unique.add(cache.identifier)
             yield message
 
     def on_signature_response(self, messages):
@@ -3317,9 +3319,10 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         Note that response_func is also called when the sub-message does not yet contain all the
         signatures.  This can be checked using sub-message.authentication.is_signed.
         """
+        community = messages[0].community
         for message in messages:
             # get cache object linked to this request and stop timeout from occurring
-            cache = self._request_cache.pop(message.payload.identifier, SignatureRequestCache)
+            cache = community.request_cache.pop(SignatureRequestCache.create_identifier(message.payload.identifier))
 
             old_submsg = cache.request.payload.message
             new_submsg = message.payload.message
@@ -3345,21 +3348,19 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         sendRequest = False
 
         # the MissingSequenceCache allows us to match the missing_high to the response_func
-        identifier = MissingSequenceCache.properties_to_identifier(community, member, message, missing_high)
-        cache = self._request_cache.get(identifier, MissingSequenceCache)
+        cache = community.request_cache.get(MissingSequenceCache.create_identifier(member, message, missing_high))
         if not cache:
-            cache = MissingSequenceCache(timeout)
-            self._request_cache.set(identifier, cache)
+            cache = community.request_cache.add(MissingSequenceCache(timeout, member, message, missing_high))
+            logger.debug("new cache: %s", cache)
 
         if response_func:
             cache.callbacks.append((response_func, response_args))
 
         # the MissingSequenceOverviewCache ensures that we do not request duplicate ranges
-        identifier = MissingSequenceOverviewCache.properties_to_identifier(community, member, message)
-        overview = self._request_cache.get(identifier, MissingSequenceOverviewCache)
+        overview = community.request_cache.get(MissingSequenceOverviewCache.create_identifier(member, message))
         if not overview:
-            overview = MissingSequenceOverviewCache(timeout)
-            self._request_cache.set(identifier, overview)
+            overview = community.request_cache.add(MissingSequenceOverviewCache(timeout, member, message))
+            logger.debug("new cache: %s", cache)
 
         if overview.missing_high == 0 or missing_high > overview.missing_high:
             missing_low = max(overview.missing_high, missing_low)
@@ -3463,12 +3464,10 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         # handle_missing_messages(messages, MissingProofCache)
 
         sendRequest = False
-        identifier = MissingProofCache.properties_to_identifier(community)
-        cache = self._request_cache.get(identifier, MissingProofCache)
+        cache = community.request_cache.get(MissingProofCache.create_identifier())
         if not cache:
-            logger.debug("%s", identifier)
-            cache = MissingProofCache(timeout)
-            self._request_cache.set(identifier, cache)
+            cache = community.request_cache.add(MissingProofCache(timeout))
+            logger.debug("new cache: %s", cache)
 
         key = (message.meta, message.authentication.member)
         if not key in cache.duplicates:
@@ -3599,12 +3598,13 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         @todo: We should raise a DelayMessageByProof to ensure that we request the proof for this
          message immediately.
         """
+        community = messages[0].community
         for message in messages:
             logger.debug("%s", message)
-            message.community.timeline.authorize(message.authentication.member, message.distribution.global_time, message.payload.permission_triplets, message)
+            community.timeline.authorize(message.authentication.member, message.distribution.global_time, message.payload.permission_triplets, message)
 
         # this might be a response to a dispersy-missing-proof or dispersy-missing-sequence
-        self.handle_missing_messages(messages, MissingProofCache, MissingSequenceCache)
+        community.handle_missing_messages(messages, MissingProofCache, MissingSequenceCache)
 
     def create_revoke(self, community, permission_triplets, sign_with_master=False, store=True, update=True, forward=True):
         """
@@ -3683,11 +3683,12 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         @todo: We should raise a DelayMessageByProof to ensure that we request the proof for this
          message immediately.
         """
+        community = messages[0].community
         for message in messages:
-            message.community.timeline.revoke(message.authentication.member, message.distribution.global_time, message.payload.permission_triplets, message)
+            community.timeline.revoke(message.authentication.member, message.distribution.global_time, message.payload.permission_triplets, message)
 
         # this might be a response to a dispersy-missing-sequence
-        self.handle_missing_messages(messages, MissingSequenceCache)
+        community.handle_missing_messages(messages, MissingSequenceCache)
 
     def create_undo(self, community, message, sign_with_master=False, store=True, update=True, forward=True):
         """
@@ -3871,17 +3872,18 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         """
         assert all(message.name in (u"dispersy-undo-own", u"dispersy-undo-other") for message in messages)
 
+        community = messages[0].community
         self._database.executemany(u"UPDATE sync SET undone = ? WHERE community = ? AND member = ? AND global_time = ?",
-                                   ((message.packet_id, message.community.database_id, message.payload.member.database_id, message.payload.global_time) for message in messages))
+                                   ((message.packet_id, community.database_id, message.payload.member.database_id, message.payload.global_time) for message in messages))
         for meta, iterator in groupby(messages, key=lambda x: x.payload.packet.meta):
             sub_messages = list(iterator)
             meta.undo_callback([(message.payload.member, message.payload.global_time, message.payload.packet) for message in sub_messages])
 
             # notify that global times have changed
-            # meta.community.update_sync_range(meta, [message.payload.global_time for message in sub_messages])
+            # community.update_sync_range(meta, [message.payload.global_time for message in sub_messages])
 
         # this might be a response to a dispersy-missing-sequence
-        self.handle_missing_messages(messages, MissingSequenceCache)
+        community.handle_missing_messages(messages, MissingSequenceCache)
 
     def create_destroy_community(self, community, degree, sign_with_master=False, store=True, update=True, forward=True):
         if __debug__:
@@ -3901,7 +3903,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         self._forward([message])
 
         # now store and update without forwarding.  forwarding now will result in new entries in our
-        # candidate table that we just cleane.
+        # candidate table that we just clean.
         self.store_update_forward([message], store, update, False)
         return message
 
@@ -4064,7 +4066,7 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
                     # meta.community.update_sync_range(meta, [message.distribution.global_time for message in redo])
 
         # this might be a response to a dispersy-missing-proof or dispersy-missing-sequence
-        self.handle_missing_messages(messages, MissingProofCache, MissingSequenceCache)
+        community.handle_missing_messages(messages, MissingProofCache, MissingSequenceCache)
 
     def sanity_check(self, community, test_identity=True, test_undo_other=True, test_binary=False, test_sequence_number=True, test_last_sync=True):
         """

--- a/dispersy.py
+++ b/dispersy.py
@@ -93,6 +93,7 @@ class SignatureRequestCache(NumberCache):
 
     @staticmethod
     def create_identifier(number):
+        assert isinstance(number, (int, long)), type(number)
         return u"request-cache:signature-request:%d" % (number,)
 
     def __init__(self, request_cache, members, response_func, response_args, timeout):
@@ -122,6 +123,7 @@ class SignatureRequestCache(NumberCache):
 class IntroductionRequestCache(NumberCache):
     @staticmethod
     def create_identifier(number):
+        assert isinstance(number, (int, long)), type(number)
         return u"request-cache:introduction-request:%d" % (number,)
 
     @property
@@ -192,6 +194,11 @@ class MissingMessageCache(MissingSomethingCache):
         assert isinstance(global_time, (int, long)), type(global_time)
         return u"request-cache:missing-message:%s:%d" % (member.mid.encode("HEX"), global_time)
 
+    @classmethod
+    def create_identifier_from_message(cls, message):
+        assert isinstance(message, Message.Implementation), type(message)
+        return cls.create_identifier(message.authentication.member, message.distribution.global_time)
+
 
 class MissingLastMessageCache(MissingSomethingCache):
 
@@ -210,6 +217,7 @@ class MissingProofCache(MissingSomethingCache):
 
     @classmethod
     def create_identifier_from_message(cls, message):
+        assert isinstance(message, Message.Implementation), type(message)
         return cls.create_identifier()
 
     def __init__(self, timeout):
@@ -256,6 +264,7 @@ class MissingSequenceCache(MissingSomethingCache):
 
     @classmethod
     def create_identifier_from_message(cls, message):
+        assert isinstance(message, Message.Implementation), type(message)
         return cls.create_identifier(message.authentication.member, message, message.distribution.sequence_number)
 
 

--- a/requestcache.py
+++ b/requestcache.py
@@ -4,13 +4,28 @@ logger = logging.getLogger(__name__)
 from random import random
 
 
-def identifier_to_string(identifier):
-    return identifier.encode("HEX") if isinstance(identifier, str) else identifier
-
-
 class Cache(object):
-    timeout_delay = 10.0
-    cleanup_delay = 10.0
+
+    @staticmethod
+    def create_identifier():
+        raise NotImplementedError()
+
+    def __init__(self, identifier):
+        assert isinstance(identifier, unicode), type(identifier)
+        self._identifier = identifier
+
+    @property
+    def identifier(self):
+        assert isinstance(self._identifier, unicode), type(self._identifier)
+        return self._identifier
+
+    @property
+    def timeout_delay(self):
+        return 10.0
+
+    @property
+    def cleanup_delay(self):
+        return 10.0
 
     def on_timeout(self):
         raise NotImplementedError()
@@ -19,107 +34,172 @@ class Cache(object):
         pass
 
     def __str__(self):
-        return "<%s>" % self.__class__.__name__
+        return "<%s identifier:%s>" % (self.__class__.__name__, self.identifier)
+
+
+class NumberCache(Cache):
+
+    @staticmethod
+    def create_identifier(number):
+        assert isinstance(number, int), type(number)
+        raise NotImplementedError()
+
+    @staticmethod
+    def create_number():
+        return int(random() * 2 ** 16)
+
+    def __init__(self, request_cache, *create_identifier_args):
+        # find an unclaimed identifier
+        while True:
+            number = self.create_number()
+            identifier = self.create_identifier(number, *create_identifier_args)
+            if not request_cache.has(identifier):
+                super(NumberCache, self).__init__(identifier)
+                self._number = number
+                break
+
+    @property
+    def number(self):
+        assert isinstance(self._number, int), type(self._number)
+        return self._number
 
 
 class RequestCache(object):
 
     def __init__(self, callback):
+        """
+        Creates a new RequestCache instance.
+        """
+        if __debug__:
+            from .callback import Callback
+            assert isinstance(callback, Callback), type(callback)
+            assert callback.is_current_thread, "RequestCache must be used on the Dispersy.callback thread"
         self._callback = callback
         self._identifiers = dict()
 
-    def generate_identifier(self):
-        while True:
-            identifier = int(random() * 2 ** 16)
-            if not identifier in self._identifiers:
-                logger.debug("claiming on %s", identifier_to_string(identifier))
-                return identifier
+    def add(self, cache):
+        """
+        Add CACHE into this RequestCache instance.
 
-    def claim(self, cache):
-        identifier = self.generate_identifier()
-        logger.debug("claiming on %s for %s", identifier_to_string(identifier), cache)
-        self.set(identifier, cache)
-        return identifier
+        Returns CACHE when CACHE.identifier was not yet added, otherwise returns None.
+        """
+        assert self._callback.is_current_thread, "RequestCache must be used on the Dispersy.callback thread"
+        assert isinstance(cache, Cache), type(cache)
+        assert isinstance(cache.identifier, unicode), type(cache.identifier)
+        assert isinstance(cache.timeout_delay, float), type(cache.timeout_delay)
+        assert cache.timeout_delay > 0.0, cache.timeout_delay
 
-    def set(self, identifier, cache):
-        assert isinstance(identifier, (int, long, str)), type(identifier)
-        assert not identifier in self._identifiers, identifier
-        assert isinstance(cache, Cache)
-        assert isinstance(cache.timeout_delay, float)
-        assert cache.timeout_delay > 0.0
+        if cache.identifier in self._identifiers:
+            logger.error("add with duplicate identifier \"%s\"", cache.identifier)
+            return None
 
-        # TODO we are slowly making all Dispersy identifiers unicode strings.  currently the request
-        # cache using stings instead, hence the conversion to HEX before giving them to _CALLBACK.
-        # once the request cache identifiers are also unicode, this HEX conversion should be removed
-
-        logger.debug("set %s for %s (%fs timeout)", identifier_to_string(identifier), cache, cache.timeout_delay)
-        self._callback.register(self._on_timeout, (identifier,), id_=u"requestcache-%s" % str(identifier).encode("HEX"), delay=cache.timeout_delay)
-        self._identifiers[identifier] = cache
-        cache.identifier = identifier
-
-    def replace(self, identifier, cache):
-        assert isinstance(identifier, (int, long, str)), type(identifier)
-        assert identifier in self._identifiers, identifier
-        assert isinstance(cache, Cache)
-        assert isinstance(cache.timeout_delay, float)
-        assert cache.timeout_delay > 0.0
-
-        logger.debug("replace %s for %s (%fs timeout)", identifier_to_string(identifier), cache, cache.timeout_delay)
-        self._callback.replace_register(u"requestcache-%s" % str(identifier).encode("HEX"), self._on_timeout, (identifier,), delay=cache.cleanup_delay)
-        self._identifiers[identifier] = cache
-        cache.identifier = identifier
-
-    def has(self, identifier, cls):
-        assert isinstance(identifier, (int, long, str)), type(identifier)
-        assert issubclass(cls, Cache), cls
-
-        logger.debug("cache contains %s? %s", identifier_to_string(identifier), identifier in self._identifiers)
-        return isinstance(self._identifiers.get(identifier), cls)
-
-    def get(self, identifier, cls):
-        assert isinstance(identifier, (int, long, str)), type(identifier)
-        assert issubclass(cls, Cache), cls
-
-        cache = self._identifiers.get(identifier)
-        if cache and isinstance(cache, cls):
+        else:
+            logger.debug("add %s", cache)
+            self._identifiers[cache.identifier] = cache
+            self._callback.register(self._on_timeout, (cache,), id_=cache.identifier, delay=cache.timeout_delay)
             return cache
 
-    def pop(self, identifier, cls):
-        assert isinstance(identifier, (int, long, str)), type(identifier)
-        assert issubclass(cls, Cache), cls
+    def replace(self, cache):
+        """
+        Replaces an existing Cache (if it exists) with CACHE.
+
+        Returns CACHE.
+        """
+        assert self._callback.is_current_thread, "RequestCache must be used on the Dispersy.callback thread"
+        assert isinstance(cache, Cache), type(cache)
+        assert isinstance(cache.identifier, unicode), type(cache.identifier)
+        assert isinstance(cache.timeout_delay, float), type(cache.timeout_delay)
+        assert cache.timeout_delay > 0.0, cache.timeout_delay
+
+        logger.debug("replace %s with %s", self._identifiers.get(cache.identifier), cache)
+        self._identifiers[cache.identifier] = cache
+        # 2013/07/23 Boudewijn: there appeared to be a bug with the delay parameter, it was using cleanup_delay instead
+        # of timeout_delay
+        self._callback.replace_register(cache.identifier, self._on_timeout, (cache,), delay=cache.timeout_delay)
+        return cache
+
+    def has(self, identifier):
+        """
+        Returns True when IDENTIFIER is part of this RequestCache.
+        """
+        assert self._callback.is_current_thread, "RequestCache must be used on the Dispersy.callback thread"
+        assert isinstance(identifier, unicode), type(identifier)
+        return identifier in self._identifiers
+
+    def get(self, identifier):
+        """
+        Returns the Cache associated with IDENTIFIER when it exists, otherwise returns None.
+        """
+        assert self._callback.is_current_thread, "RequestCache must be used on the Dispersy.callback thread"
+        assert isinstance(identifier, unicode), type(identifier)
+        return self._identifiers.get(identifier)
+
+    def pop(self, identifier):
+        """
+        Returns the Cache associated with IDENTIFIER, and removes it from this RequestCache, when it exists, otherwise
+        returns None.
+        """
+        assert self._callback.is_current_thread, "RequestCache must be used on the Dispersy.callback thread"
+        assert isinstance(identifier, unicode), type(identifier)
 
         cache = self._identifiers.get(identifier)
-        if cache and isinstance(cache, cls):
+        if cache:
             assert isinstance(cache.cleanup_delay, float)
             assert cache.cleanup_delay >= 0.0
-            logger.debug("canceling timeout on %s for %s", identifier_to_string(identifier), cache)
+            logger.debug("cancel timeout for %s", cache)
 
             if cache.cleanup_delay:
-                self._callback.replace_register(u"requestcache-%s" % str(identifier).encode("HEX"), self._on_cleanup, (identifier,), delay=cache.cleanup_delay)
+                self._callback.replace_register(identifier, self._on_cleanup, (cache,), delay=cache.cleanup_delay)
 
-            elif identifier in self._identifiers:
-                self._callback.unregister(u"requestcache-%s" % str(identifier).encode("HEX"))
+            else:
+                self._callback.unregister(identifier)
                 del self._identifiers[identifier]
 
             return cache
 
-    def _on_timeout(self, identifier):
-        assert identifier in self._identifiers, identifier
-        cache = self._identifiers[identifier]
-        logger.debug("timeout on %s for %s", identifier_to_string(identifier), cache)
+    def _on_timeout(self, cache):
+        """
+        Called CACHE.timeout_delay seconds after CACHE was added to this RequestCache.
+
+        _on_timeout is called for every Cache, except when it has been popped before the timeout expires.  When called
+        _on_timeout will:
+        - call CACHE.on_timeout().
+        - when CACHE.cleanup_delay == 0.0: removes CACHE, freeing CACHE.identifier to be used again.
+        - when CACHE.cleanup_delay > 0.0: schedules _on_cleanup to be called after CACHE.cleanup_delay seconds.
+        """
+        # if not cache.identifier in self._identifiers:
+        #     logger.error("_on_timeout with unknown identifier \"%s\"", cache.identifier)
+        #     return
+
+        assert self._callback.is_current_thread, "RequestCache must be used on the Dispersy.callback thread"
+        assert isinstance(cache, Cache), type(cache)
+        assert cache.identifier in self._identifiers, cache
+
+        logger.debug("timeout on %s", cache)
         cache.on_timeout()
 
         if cache.cleanup_delay:
-            self._callback.replace_register(u"requestcache-%s" % str(identifier).encode("HEX"), self._on_cleanup, (identifier,), delay=cache.cleanup_delay)
+            self._callback.replace_register(cache.identifier, self._on_cleanup, (cache,), delay=cache.cleanup_delay)
 
-        elif identifier in self._identifiers:
-            del self._identifiers[identifier]
+        else:
+            del self._identifiers[cache.identifier]
 
-    def _on_cleanup(self, identifier):
-        assert identifier in self._identifiers
-        cache = self._identifiers[identifier]
-        logger.debug("cleanup on %s for %s", identifier_to_string(identifier), cache)
+    def _on_cleanup(self, cache):
+        """
+        Called CACHE.cleanup_delay seconds after CACHE had either a timeout or was popped.
+
+        _on_cleanup is called for every Cache that has CAHCHE.cleanup_delay > 0.0.  When called _on_cleanup will:
+        - call CACHE.on_cleanup().
+        - removes CACHE, freeing CACHE.identifier to be used again.
+        """
+        # if not cache.identifier in self._identifiers:
+        #     logger.error("_on_cleanup with unknown identifier \"%s\"", cache.identifier)
+        #     return
+
+        assert self._callback.is_current_thread, "RequestCache must be used on the Dispersy.callback thread"
+        assert cache.identifier in self._identifiers, cache
+
+        logger.debug("cleanup on %s", cache)
         cache.on_cleanup()
+        del self._identifiers[cache.identifier]
 
-        if identifier in self._identifiers:
-            del self._identifiers[identifier]

--- a/tests/debugcommunity/community.py
+++ b/tests/debugcommunity/community.py
@@ -6,6 +6,7 @@ from ...candidate import Candidate
 from ...community import Community, HardKilledCommunity
 from ...conversion import DefaultConversion
 from ...destination import CommunityDestination
+from ...dispersy import MissingSequenceCache
 from ...distribution import DirectDistribution, FullSyncDistribution, LastSyncDistribution, GlobalTimePruning
 from ...message import Message, DelayMessageByProof
 from ...resolution import PublicResolution, LinearResolution, DynamicResolution
@@ -171,6 +172,9 @@ class DebugCommunity(Community):
         for message in messages:
             if not "Dprint=False" in message.payload.text:
                 logger.debug("%s \"%s\" @%d", message, message.payload.text, message.distribution.global_time)
+
+        if messages[0].distribution.enable_sequence_number:
+            self.handle_missing_messages(messages, MissingSequenceCache)
 
     def undo_text(self, descriptors):
         """

--- a/tests/test_requestcache.py
+++ b/tests/test_requestcache.py
@@ -1,0 +1,114 @@
+from ..requestcache import RequestCache, NumberCache
+from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
+
+class TestRequestCache(DispersyTestFunc):
+
+    @call_on_dispersy_thread
+    def test_single_cache(self):
+        """
+        Tests standard add, has, get, and pop behaviour.
+        """
+        class Cache(NumberCache):
+            @staticmethod
+            def create_identifier(number):
+                return u"request-cache:test:%d" % (number,)
+
+            @property
+            def cleanup_delay(self):
+                return 0.0
+
+        request_cache = RequestCache(self._dispersy.callback)
+        cache = Cache(request_cache)
+        self.assertIsNotNone(cache)
+        self.assertFalse(request_cache.has(cache.identifier))
+        self.assertIsNone(request_cache.get(cache.identifier))
+        self.assertIsNone(request_cache.pop(cache.identifier))
+        # add cache
+        self.assertEqual(request_cache.add(cache), cache)
+        self.assertTrue(request_cache.has(cache.identifier))
+        self.assertEqual(request_cache.get(cache.identifier), cache)
+        # remove
+        self.assertEqual(request_cache.pop(cache.identifier), cache)
+        # has, get, and pop fail because cache.cleanup_delay == 0.0
+        self.assertFalse(request_cache.has(cache.identifier))
+        self.assertIsNone(request_cache.get(cache.identifier))
+        self.assertIsNone(request_cache.pop(cache.identifier))
+
+    @call_on_dispersy_thread
+    def test_multiple_caches(self):
+        """
+        Tests standard add, has, get, and pop behaviour.
+        """
+        class Cache(NumberCache):
+            @staticmethod
+            def create_identifier(number):
+                return u"request-cache:test:%d" % (number,)
+
+            @property
+            def cleanup_delay(self):
+                return 0.0
+
+        request_cache = RequestCache(self._dispersy.callback)
+
+        caches = []
+        for _ in xrange(100):
+            cache = Cache(request_cache)
+            self.assertIsNotNone(cache)
+            self.assertFalse(request_cache.has(cache.identifier))
+            self.assertIsNone(request_cache.get(cache.identifier))
+            self.assertIsNone(request_cache.pop(cache.identifier))
+            # add cache (must be done before generating the next cache, otherwise number clashes can occur)
+            self.assertEqual(request_cache.add(cache), cache)
+            caches.append(cache)
+
+        # all identifiers must be unique
+        self.assertEqual(len(caches), len(set(cache.identifier for cache in caches)))
+        # all numbers must be unique
+        self.assertEqual(len(caches), len(set(cache.number for cache in caches)))
+
+        for cache in caches:
+            self.assertTrue(request_cache.has(cache.identifier))
+            self.assertEqual(request_cache.get(cache.identifier), cache)
+
+        for cache in caches:
+            # remove
+            self.assertEqual(request_cache.pop(cache.identifier), cache)
+            # has, get, and pop fail because cache.cleanup_delay == 0.0
+            self.assertFalse(request_cache.has(cache.identifier))
+            self.assertIsNone(request_cache.get(cache.identifier))
+            self.assertIsNone(request_cache.pop(cache.identifier))
+
+    @call_on_dispersy_thread
+    def test_request_cache_double_pop_bug(self):
+        """
+        Demonstrates the strange and unexpected pop behaviour when Cache.cleanup_delay > 0.0.
+
+        TODO this test should be removed when the unexpected behaviour is solved.
+        """
+        class Cache(NumberCache):
+            @staticmethod
+            def create_identifier(number):
+                return u"request-cache:test:%d" % (number,)
+
+            @property
+            def cleanup_delay(self):
+                return 10.0
+
+        request_cache = RequestCache(self._dispersy.callback)
+        cache = Cache(request_cache)
+        self.assertIsNotNone(cache)
+        self.assertFalse(request_cache.has(cache.identifier))
+        self.assertIsNone(request_cache.get(cache.identifier))
+        self.assertIsNone(request_cache.pop(cache.identifier))
+        # add cache
+        self.assertEqual(request_cache.add(cache), cache)
+        self.assertTrue(request_cache.has(cache.identifier))
+        self.assertEqual(request_cache.get(cache.identifier), cache)
+        # remove
+        self.assertEqual(request_cache.pop(cache.identifier), cache)
+
+        # has, get, and pop keep working because cache.cleanup_delay > 0.0.  Note that this is very strange and
+        # unexpected!  Why is it still there when it was just popped?
+        self.assertTrue(request_cache.has(cache.identifier))
+        self.assertEqual(request_cache.get(cache.identifier), cache)
+        self.assertEqual(request_cache.pop(cache.identifier), cache)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -5,7 +5,7 @@ from .debugcommunity.node import DebugNode
 from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
 
 
-class TestSequence(DispersyTestFunc):
+class TestIncomingMissingSequence(DispersyTestFunc):
 
     @call_on_dispersy_thread
     def incoming_simple_conflict_different_global_time(self):
@@ -340,14 +340,14 @@ class TestSequence(DispersyTestFunc):
                 assert message.distribution.sequence_number == i
                 self._messages.append(message)
 
-        super(TestSequence, self).setUp()
+        super(TestIncomingMissingSequence, self).setUp()
         self._dispersy.callback.call(on_dispersy_thread)
 
     @call_on_dispersy_thread
     def requests(self, node_count, responses, *pairs):
         """
-        NODE1 and NODE2 requests (non)overlapping sequences, SELF should send back the requested
-        messages only once.
+        NODE1 through NODE<NODE_COUNT> requests (non)overlapping sequences, SELF should send back the requested messages
+        only once.
         """
         community = self._community
         nodes = self._nodes[:node_count]
@@ -380,3 +380,59 @@ class TestSequence(DispersyTestFunc):
         # there should not be any no further responses
         for node in nodes:
             self.assertEqual(node.receive_messages(message_names=[meta.name]), [], "should not yet have any responses")
+
+class TestOutgoingMissingSequence(DispersyTestFunc):
+
+    @call_on_dispersy_thread
+    def test_missing(self):
+        """
+        NODE sends message while SELF doesn't have the prior sequence numbers, SELF should request these messages.
+        """
+        community = DebugCommunity.create_community(self._dispersy, self._my_member)
+        node = DebugNode(community)
+        node.init_socket()
+        node.init_my_member()
+
+        messages = [node.create_sequence_text("Sequence message #%d" % sequence, sequence + 10, sequence)
+                    for sequence
+                    in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
+
+        # NODE gives #5, hence SELF will request [#1:#4]
+        node.give_message(messages[4])
+        requests = node.receive_messages(message_names=[u"dispersy-missing-sequence"])
+        self.assertEqual(len(requests), 1)
+        _, request = requests[0]
+
+        print "Got request", request.payload.missing_low, "-", request.payload.missing_high
+        self.assertEqual(request.payload.member.public_key, node.my_member.public_key)
+        self.assertEqual(request.payload.message.name, u"sequence-text")
+        self.assertEqual(request.payload.missing_low, 1)
+        self.assertEqual(request.payload.missing_high, 4)
+
+        # NODE gives the missing packets, database should now contain [#1:#5]
+        node.give_messages(messages[0:4])
+        yield 0.11
+        packets = community.fetch_packets(u"sequence-text")
+        self.assertEqual(packets, [message.packet for message in messages[0:5]])
+
+        #
+        # Lets give the following range and test if it works when there are already (a few) messages in the database
+        #
+
+        # NODE gives #10, hence SELF will request [#6:#9]
+        node.give_message(messages[9])
+        requests = node.receive_messages(message_names=[u"dispersy-missing-sequence"])
+        self.assertEqual(len(requests), 1)
+        _, request = requests[0]
+
+        print "Got request", request.payload.missing_low, "-", request.payload.missing_high
+        self.assertEqual(request.payload.member.public_key, node.my_member.public_key)
+        self.assertEqual(request.payload.message.name, u"sequence-text")
+        self.assertEqual(request.payload.missing_low, 6)
+        self.assertEqual(request.payload.missing_high, 9)
+
+        # NODE gives the missing packets, database should now contain [#1:#5]
+        node.give_messages(messages[5:9])
+        yield 0.11
+        packets = community.fetch_packets(u"sequence-text")
+        self.assertEqual(packets, [message.packet for message in messages])

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -403,7 +403,6 @@ class TestOutgoingMissingSequence(DispersyTestFunc):
         self.assertEqual(len(requests), 1)
         _, request = requests[0]
 
-        print "Got request", request.payload.missing_low, "-", request.payload.missing_high
         self.assertEqual(request.payload.member.public_key, node.my_member.public_key)
         self.assertEqual(request.payload.message.name, u"sequence-text")
         self.assertEqual(request.payload.missing_low, 1)
@@ -425,7 +424,6 @@ class TestOutgoingMissingSequence(DispersyTestFunc):
         self.assertEqual(len(requests), 1)
         _, request = requests[0]
 
-        print "Got request", request.payload.missing_low, "-", request.payload.missing_high
         self.assertEqual(request.payload.member.public_key, node.my_member.public_key)
         self.assertEqual(request.payload.message.name, u"sequence-text")
         self.assertEqual(request.payload.missing_low, 6)


### PR DESCRIPTION
- Identifiers are now unicode strings, these are used as keys in the
  RequestCache instance and as Callback id's.
- Cache now takes a unicode string as a parameter, this is the
  identifier.  Older code set the identifier (outside of the Cache
  constructor) once the cache was added to the RequestCache.
- NumberCache is used when, instead of a predefined unicode string,
  the identifier must contain a random number.  This is used by, for
  instance, the introduction-request message.  The random number is
  available from the 'Cache.number' property, while the
  'Cache.identifier' property still contains the unicode string.
  
  Note that this means that any older code that used to encode
  Cache.identifier into a request or response message must now use
  Cache.number instead.
- The static method Cache.create_identifier is used to generate a
  Cache specific unicode string.  Parameters can be supplied to add
  unique features, such as the number in NumberCache.
  
  Note that the generic method 'handle_missing_messages' needs to get
  the identifier from a message instance.  This is done using
  Cache.create_identifier_from_message, which in turn should call
  Cache.create_identifier with the appropriate parameters obtained
  from the message instance.  Code that uses 'handle_missing_messages'
  must ensure their Cache object supplies
  'create_identifier_from_message'
- RequestCache.add(CACHE) replaces RequestCache.set(ID, CACHE).
  RequestCache.add will return None when CACHE.identifier is already
  in use.
- RequestCache.claim no longer exists.  A valid (read unused)
  identifier can be found using RequestCache.has or repeated calls to
  RequestCache.add, while checking its return value.
- RequestCache.{replace, has, get} have had their parameters modified
  to reflect the introduction of the unicode string identifier.
