### PR TITLE
Fixes missing logger configuration.

### DIFF
--- a/tool/main.py
+++ b/tool/main.py
@@ -2,9 +2,12 @@
 Run Dispersy in standalone mode.
 """
 
-import logging
 import logging.config
-logging.config.fileConfig("logger.conf")
+try:
+    logging.config.fileConfig("logger.conf")
+except:
+    print "Unable to load logging config from 'logger.conf' file."
+logging.basicConfig(format="%(asctime)-15s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
 # optparse is deprecated since python 2.7

--- a/tool/tracker.py
+++ b/tool/tracker.py
@@ -19,7 +19,12 @@ Note that there is no output for REQ_IN2 for destroyed overlays.  Instead a DEST
 whenever a introduction request is received for a destroyed overlay.
 """
 
-import logging
+import logging.config
+try:
+    logging.config.fileConfig("logger.conf")
+except:
+    print "Unable to load logging config from 'logger.conf' file."
+logging.basicConfig(format="%(asctime)-15s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":


### PR DESCRIPTION
We have been having problems with the logger not showing important
messages because it has no handler assigned to it.  We fix this by
reading an optional logger.conf, and using basicConfig to ensure at
least one handler is always assigned.
