### PR TITLE
Using Python's abc to handle abstract methods and properties.

### DIFF
--- a/authentication.py
+++ b/authentication.py
@@ -10,6 +10,7 @@ creator of this message.
 @contact: dispersy@frayja.com
 """
 
+from abc import ABCMeta, abstractproperty
 from .meta import MetaObject
 
 
@@ -25,13 +26,15 @@ class Authentication(MetaObject):
         The implementation of an Authentication policy.
         """
 
-        @property
+        __metaclass__ = ABCMeta
+
+        @abstractproperty
         def is_signed(self):
             """
             True when the message is (correctly) signed, False otherwise.
             @rtype: bool
             """
-            raise NotImplementedError()
+            pass
 
         def setup(self, message_impl):
             if __debug__:

--- a/community.py
+++ b/community.py
@@ -11,7 +11,7 @@ Community instance.
 import logging
 logger = logging.getLogger(__name__)
 
-from hashlib import sha1
+from abc import ABCMeta, abstractmethod
 from itertools import islice
 from math import ceil
 from random import random, Random, randint, shuffle
@@ -49,6 +49,8 @@ class SyncCache(object):
 
 
 class Community(object):
+    __metaclass__ = ABCMeta
+
     # Probability steps to get a sync skipped if the previous one was empty
     _SKIP_CURVE_STEPS = [0, 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
     _SKIP_STEPS = len(_SKIP_CURVE_STEPS)
@@ -1844,6 +1846,7 @@ class Community(object):
         """
         return self._meta_messages.values()
 
+    @abstractmethod
     def initiate_meta_messages(self):
         """
         Create the meta messages for one community instance.
@@ -1857,8 +1860,9 @@ class Community(object):
         @return: The new meta messages.
         @rtype: [Message]
         """
-        raise NotImplementedError(self)
+        pass
 
+    @abstractmethod
     def initiate_conversions(self):
         """
         Create the Conversion instances for this community instance.
@@ -1871,7 +1875,7 @@ class Community(object):
 
         @rtype: [Conversion]
         """
-        raise NotImplementedError(self)
+        pass
 
 
 class HardKilledCommunity(Community):

--- a/conversion.py
+++ b/conversion.py
@@ -1,7 +1,7 @@
 import logging
 logger = logging.getLogger(__name__)
 
-from hashlib import sha1
+from abc import ABCMeta, abstractmethod
 from math import ceil
 from socket import inet_ntoa, inet_aton
 from struct import pack, unpack_from, Struct
@@ -30,6 +30,9 @@ class Conversion(object):
     community version.  If also allows outgoing messages to be converted to a different, possibly
     older, community version.
     """
+
+    __metaclass__ = ABCMeta
+
     def __init__(self, community, dispersy_version, community_version):
         """
         COMMUNITY instance that this conversion belongs to.
@@ -78,13 +81,14 @@ class Conversion(object):
     def prefix(self):
         return self._prefix
 
+    @abstractmethod
     def can_decode_message(self, data):
         """
         Returns True when DATA can be decoded using this conversion.
         """
         assert isinstance(data, str), type(data)
-        raise NotImplementedError("The subclass must implement decode_message")
 
+    @abstractmethod
     def decode_meta_message(self, data):
         """
         Obtain the dispersy meta message from DATA.
@@ -93,8 +97,8 @@ class Conversion(object):
         assert isinstance(data, str)
         assert len(data) >= 22
         assert data[:22] == self._prefix
-        raise NotImplementedError("The subclass must implement decode_message")
 
+    @abstractmethod
     def decode_message(self, address, data, verify=True):
         """
         DATA is a string, where the first byte is the on-the-wire Dispersy version, the second byte
@@ -106,15 +110,15 @@ class Conversion(object):
         assert isinstance(data, str)
         assert len(data) >= 22
         assert data[:22] == self._prefix
-        raise NotImplementedError("The subclass must implement decode_message")
 
+    @abstractmethod
     def can_encode_message(self, message):
         """
         Returns True when MESSAGE can be encoded using this conversion.
         """
         assert isinstance(message, (Message, Message.Implementation)), type(message)
-        raise NotImplementedError("The subclass must implement can_encode_message")
 
+    @abstractmethod
     def encode_message(self, message, sign=True):
         """
         Encode a Message instance into a binary string where the first byte is the on-the-wire
@@ -123,8 +127,8 @@ class Conversion(object):
 
         Returns a binary string.
         """
-        assert isinstance(message, Message)
-        raise NotImplementedError("The subclass must implement encode_message")
+        assert isinstance(message, Message), type(message)
+        assert isinstance(sign, bool), type(sign)
 
     def __str__(self):
         return "<%s %s%s>" % (self.__class__.__name__, self.dispersy_version.encode("HEX"), self.community_version.encode("HEX"))

--- a/database.py
+++ b/database.py
@@ -10,6 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import sys
+from abc import ABCMeta, abstractmethod
 from sqlite3 import Connection, Error
 
 from .decorator import attach_runtime_statistics
@@ -57,6 +58,8 @@ class IgnoreCommits(Exception):
 
 
 class Database(object):
+
+    __metaclass__ = ABCMeta
 
     def __init__(self, file_path):
         """
@@ -399,6 +402,7 @@ class Database(object):
 
             return self._connection.commit()
 
+    @abstractmethod
     def check_database(self, database_version):
         """
         Check the database and upgrade if required.
@@ -415,7 +419,7 @@ class Database(object):
          value reverts to u'0' when the table could not be accessed.
         @type database_version: unicode
         """
-        raise NotImplementedError()
+        pass
 
     def attach_commit_callback(self, func):
         assert not func in self._commit_callbacks

--- a/distribution.py
+++ b/distribution.py
@@ -1,5 +1,3 @@
-from .meta import MetaObject
-
 """
 Each Privilege can be distributed, usualy through the transfer of a message, in different ways.
 These ways are defined by DistributionMeta object that is associated to the Privilege.
@@ -16,10 +14,15 @@ LastSyncDistribution object holds additional information for this specific messa
 global_time.
 """
 
+from abc import ABCMeta, abstractmethod
+from .meta import MetaObject
+
 
 class Pruning(MetaObject):
 
     class Implementation(MetaObject.Implementation):
+
+        __metaclass__ = ABCMeta
 
         def __init__(self, meta, distribution):
             assert isinstance(distribution, SyncDistribution.Implementation), type(distribution)
@@ -35,14 +38,17 @@ class Pruning(MetaObject):
                 return "pruned"
             raise RuntimeError("Unable to obtain pruning state")
 
+        @abstractmethod
         def is_active(self):
-            raise NotImplementedError("missing implementation")
+            pass
 
+        @abstractmethod
         def is_inactive(self):
-            raise NotImplementedError("missing implementation")
+            pass
 
+        @abstractmethod
         def is_pruned(self):
-            raise NotImplementedError("missing implementation")
+            pass
 
 
 class NoPruning(Pruning):

--- a/endpoint.py
+++ b/endpoint.py
@@ -1,6 +1,7 @@
 import logging
 logger = logging.getLogger(__name__)
 
+from abc import ABCMeta, abstractmethod
 from itertools import product
 from select import select
 from time import time
@@ -20,6 +21,7 @@ TUNNEL_PREFIX = "ffffffff".decode("HEX")
 
 
 class Endpoint(object):
+    __metaclass__ = ABCMeta
 
     def __init__(self):
         self._dispersy = None
@@ -50,11 +52,13 @@ class Endpoint(object):
         self._total_send = 0
         self._cur_sendqueue = 0
 
+    @abstractmethod
     def get_address(self):
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def send(self, candidates, packets):
-        raise NotImplementedError()
+        pass
 
     def open(self, dispersy):
         self._dispersy = dispersy

--- a/message.py
+++ b/message.py
@@ -1,6 +1,7 @@
 import logging
 logger = logging.getLogger(__name__)
 
+from abc import ABCMeta, abstractmethod
 from .meta import MetaObject
 
 #
@@ -13,15 +14,19 @@ class DelayPacket(Exception):
     """
     Uses an identifier to match request to response.
     """
+
+    __metaclass__ = ABCMeta
+
     def __init__(self, msg, community):
         super(DelayPacket, self).__init__(msg)
         self._community = community
 
+    @abstractmethod
     def create_request(self, candidate, delayed):
         # create and send a request.  once the response is received the _process_delayed_packet can
         # pass the (candidate, delayed) tuple to dispersy for reprocessing
         # @return True if actual request is made
-        raise NotImplementedError()
+        pass
 
     def _process_delayed_packet(self, response, candidate, delayed):
         if response:
@@ -97,6 +102,9 @@ class DelayMessage(Exception):
     Ensure to call Dispersy.handle_missing_messages for each incoming message that may have been
     requested.
     """
+
+    __metaclass__ = ABCMeta
+
     def __init__(self, delayed):
         if __debug__:
             from .message import Message
@@ -114,11 +122,12 @@ class DelayMessage(Exception):
         """
         return self.__class__(delayed)
 
+    @abstractmethod
     def create_request(self):
         # create and send a request.  once the response is received the _process_delayed_message can
         # pass the (candidate, delayed) tuple to dispersy for reprocessing
         # @return True if actual request is made
-        raise NotImplementedError()
+        pass
 
     def _process_delayed_message(self, response):
         if response:

--- a/script.py
+++ b/script.py
@@ -1,6 +1,7 @@
 import logging
 logger = logging.getLogger(__name__)
 
+from abc import ABCMeta, abstractmethod
 from time import time
 
 from .tests.debugcommunity.community import DebugCommunity
@@ -14,6 +15,8 @@ def assert_(value, *args):
 
 
 class ScriptBase(object):
+
+    __metaclass__ = ABCMeta
 
     def __init__(self, dispersy, **kargs):
         assert isinstance(dispersy, Dispersy), type(dispersy)
@@ -57,8 +60,9 @@ class ScriptBase(object):
         logger.warning("depricated: use add_testcase instead")
         return self.add_testcase(run, args)
 
+    @abstractmethod
     def run(self):
-        raise NotImplementedError("Must implement a generator or use self.add_testcase(...)")
+        pass
 
     @property
     def enable_wait_for_wan_address(self):
@@ -190,11 +194,13 @@ class ScenarioScriptBase(ScriptBase):
     def log_desync(self, desync):
         log(self._logfile, "sleep", desync=desync, stepcount=self._stepcount)
 
+    @abstractmethod
     def join_community(self, my_member):
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def execute_scenario_cmds(self, commands):
-        raise NotImplementedError()
+        pass
 
     def run(self):
         self.add_testcase(self._run)

--- a/statistics.py
+++ b/statistics.py
@@ -1,16 +1,20 @@
+from abc import ABCMeta, abstractmethod
 from time import time
 from collections import defaultdict
 
 
 class Statistics(object):
 
+    __metaclass__ = ABCMeta
+
     @staticmethod
     def dict_inc(dictionary, key, value=1):
         if dictionary != None:
             dictionary[key] += value
 
+    @abstractmethod
     def update(self):
-        raise NotImplementedError()
+        pass
 
     def get_dict(self):
         """

--- a/tool/scenarioscript.py
+++ b/tool/scenarioscript.py
@@ -13,6 +13,7 @@ except ImportError:
     Process = cpu_percent = None
     print "Unable to import from psutil.  Process statistics are disabled"
 
+from abc import ABCMeta, abstractproperty
 from hashlib import sha1
 from os import getpid, uname, path
 from random import random, uniform
@@ -28,6 +29,8 @@ from .ldecoder import Parser, NextFile
 
 
 class ScenarioScript(ScriptBase):
+
+    __metaclass__ = ABCMeta
 
     def __init__(self, *args, **kargs):
         super(ScenarioScript, self).__init__(*args, **kargs)
@@ -63,18 +66,18 @@ class ScenarioScript(ScriptBase):
     def my_member_security(self):
         return u"low"
 
-    @property
+    @abstractproperty
     def master_member_public_key(self):
-        raise NotImplementedError("must return an experiment specific master member public key")
+        pass
             # if False:
             # when crypto.py is disabled a public key is slightly
             # different...
             #     master_public_key = ";".join(("60", master_public_key[:60].encode("HEX"), ""))
         # return "3081a7301006072a8648ce3d020106052b81040027038192000404668ed626c6d6bf4a280cf4824c8cd31fe4c7c46767afb127129abfccdf8be3c38d4b1cb8792f66ccb603bfed395e908786049cb64bacab198ef07d49358da490fbc41f43ade33e05c9991a1bb7ef122cda5359d908514b3c935fe17a3679b6626161ca8d8d934d372dec23cc30ff576bfcd9c292f188af4142594ccc5f6376e2986e1521dc874819f7bcb7ae3ce400".decode("HEX")
 
-    @property
+    @abstractproperty
     def community_class(self):
-        raise NotImplementedError("must return an experiment community class")
+        pass
 
     @property
     def community_args(self):


### PR DESCRIPTION
Since Python 2.6 the abc module provides a way to define abstract
methods and properties.  Before this the convention was to raise a
NotImplementedError.

Using abc will ensure an error is given when an object is instantiated
instead of waiting for the abstract method/property to be called.
