### PR TITLE
Dispersy.stop will now return either True or False.

### DIFF
--- a/database.py
+++ b/database.py
@@ -96,6 +96,7 @@ class Database(object):
         self._connect()
         self._initial_statements()
         self._prepare_version()
+        return True
 
     def close(self, commit=True):
         assert self._cursor is not None, "Database.close() has been called or Database.open() has not been called"
@@ -107,6 +108,7 @@ class Database(object):
         self._cursor = None
         self._connection.close()
         self._connection = None
+        return True
 
     def _connect(self):
         self._connection = Connection(self._file_path)

--- a/tests/dispersytestclass.py
+++ b/tests/dispersytestclass.py
@@ -30,8 +30,10 @@ class DispersyTestFunc(TestCase):
     def on_callback_exception(self, exception, is_fatal):
         logger.exception("%s", exception)
 
-        # properly shutdown Dispersy
-        self._dispersy.stop()
+        # properly shutdown Dispersy, note that it will always return False since
+        # on_callback_exception is running on the callback thread making it impossible to have the
+        # thread closed while this call is still being performed
+        self.assertFalse(self._dispersy.stop())
         self._dispersy = None
 
         # consider every exception a fatal error
@@ -47,6 +49,7 @@ class DispersyTestFunc(TestCase):
         working_directory = u"."
         database_filename = u":memory:"
 
+        self._dispersy_stop_success = None
         self._dispersy = Dispersy(callback, endpoint, working_directory, database_filename)
         self._dispersy.start()
         self._my_member = callback.call(self._dispersy.get_new_member, (u"low",))
@@ -56,6 +59,6 @@ class DispersyTestFunc(TestCase):
         logger.debug("tearDown")
 
         if self._dispersy:
-            self._dispersy.stop()
+            self.assertTrue(self._dispersy.stop())
             self._dispersy = None
         self._my_member = None


### PR DESCRIPTION
Previously Dispersy.stop would always return True.  Now the return value
depends on the various elements that are stopped/closed, i.e. endpoint,
database, and callback.

Fixes https://github.com/Tribler/dispersy/issues/91
