### PR TITLE
Moved the majority of _loop into _one_step

### DIFF
--- a/callback.py
+++ b/callback.py
@@ -684,9 +684,9 @@ class Callback(object):
 
         # call all expired tasks and send GeneratorExit exceptions to expired generators, note that
         # new tasks will not be accepted
-        logger.debug("there are %d expired tasks", len(self._expired))
-        while self._expired:
-            _, _, _, call, callback = heappop(self._expired)
+        logger.debug("there are %d expired tasks", len(self._expired_mirror))
+        while self._expired_mirror:
+            _, _, _, call, callback = heappop(self._expired_mirror)
             if isinstance(call, TupleType):
                 try:
                     result = call[0](*call[1], **call[2])
@@ -719,9 +719,9 @@ class Callback(object):
                         logger.exception("%s", exception)
 
         # send GeneratorExit exceptions to scheduled generators
-        logger.debug("there are %d scheduled tasks", len(self._requests))
-        while self._requests:
-            _, _, _, call, callback = heappop(self._requests)
+        logger.debug("there are %d scheduled tasks", len(self._requests_mirror))
+        while self._requests_mirror:
+            _, _, _, call, callback = heappop(self._requests_mirror)
             if isinstance(call, GeneratorType):
                 logger.debug("raise Shutdown in %s", call)
                 try:

--- a/callback.py
+++ b/callback.py
@@ -621,11 +621,9 @@ class Callback(object):
                         heappush(self._requests, (time() + result, priority, root_id, call, callback))
 
             except StopIteration:
-                # TODO: found UnboundLocalError bug
-                result = None
                 if callback:
                     with self._lock:
-                        heappush(self._expired, (priority, actual_time, root_id, None, (callback[0], (result,) + callback[1], callback[2]), None))
+                        heappush(self._expired, (priority, actual_time, root_id, None, (callback[0], (None,) + callback[1], callback[2]), None))
 
             except (SystemExit, KeyboardInterrupt, GeneratorExit) as exception:
                 with self._lock:

--- a/callback.py
+++ b/callback.py
@@ -455,15 +455,16 @@ class Callback(object):
 
         def callback(result):
             if isinstance(result, Exception):
-                container[1] = exc_info()
+                container[1] = result
+                container[2] = exc_info()
 
             else:
                 container[0] = result
 
             event.set()
 
-        # result container with [RETURN-VALUE, EXC_INFO-TUPLE]
-        container = [default, None]
+        # result container with [RETURN-VALUE, EXCEPTION-INSTANCE, EXC_INFO-TUPLE]
+        container = [default, None, None]
         event = Event()
 
         # register the call
@@ -481,8 +482,12 @@ class Callback(object):
             event.wait(None if timeout == 0.0 else timeout)
 
         if container[1]:
-            type_, value, traceback = container[1]
-            raise type_, value, traceback
+            if container[2][0] is None:
+                raise container[1]
+
+            else:
+                type_, value, traceback = container[2]
+                raise type_, value, traceback
 
         else:
             return container[0]

--- a/callback.py
+++ b/callback.py
@@ -446,26 +446,19 @@ class Callback(object):
 
         # result container with [RETURN-VALUE, EXC_INFO-TUPLE]
         container = [default, None]
+        event = Event()
+
+        # register the call
+        self.register(call, args, kargs, delay, priority, id_, callback, include_id=include_id)
 
         if self._thread_ident == get_ident():
-            if kargs:
-                container[0] = call(*args, **kargs)
-            else:
-                container[0] = call(*args)
-
-            if isinstance(container[0], GeneratorType):
-                logger.warning("using callback.call from the same thread on a generator can cause deadlocks")
-                for delay in container[0]:
-                    sleep(delay)
-
-                container[0] = default
+            # TODO timeout is not taken into account right now
+            while self._one_task():
+                # wait for call to finish
+                if event.is_set():
+                    break
 
         else:
-            event = Event()
-
-            # register the call
-            self.register(call, args, kargs, delay, priority, id_, callback, include_id=include_id)
-
             # wait for call to finish
             event.wait(None if timeout == 0.0 else timeout)
 
@@ -543,144 +536,145 @@ class Callback(object):
 
         self._loop()
 
-    @attach_profiler
-    def _loop(self):
+    def _one_task(self):
         if __debug__:
             time_since_expired = 0
 
-        # put some often used methods and object in the local namespace
-        actual_time = 0
-        event_clear = self._event.clear
-        event_wait = self._event.wait
-        event_is_set = self._event.isSet
-        expired = self._expired
-        get_timestamp = time
-        lock = self._lock
-        requests = self._requests
+        actual_time = time()
 
+        with self._lock:
+            # check if we should continue to run
+            if self._state != "STATE_RUNNING":
+                # break
+                return False
+
+            # move expired requests from self._REQUESTS to self._EXPIRED
+            while self._requests and self._requests[0][0] <= actual_time:
+                # notice that the deadline and priority entries are switched, hence, the entries in
+                # the self._EXPIRED list are ordered by priority instead of deadline
+                deadline, priority, root_id, call, callback = heappop(self._requests)
+                heappush(self._expired, (priority, deadline, root_id, None, call, callback))
+
+            if self._expired:
+                if __debug__ and len(self._expired) > 10:
+                    if not time_since_expired:
+                        time_since_expired = actual_time
+
+                # we need to handle the next call in line
+                priority, deadline, root_id, _, call, callback = heappop(self._expired)
+                wait = 0.0
+
+                if __debug__:
+                    self._debug_call_name = self._debug_call_to_string(call)
+
+                # ignore removed tasks
+                if call is None:
+                    # continue
+                    return True
+
+            else:
+                # there is nothing to handle
+                wait = self._requests[0][0] - actual_time if self._requests else 300.0
+                if __debug__:
+                    logger.debug("nothing to handle, wait %.2f seconds", wait)
+                    if time_since_expired:
+                        diff = actual_time - time_since_expired
+                        if diff > 1.0:
+                            logger.warning("took %.2f to process expired queue", diff)
+                        time_since_expired = 0
+
+            if self._event.is_set():
+                self._event.clear()
+
+        if wait:
+            logger.debug("wait at most %.3fs before next call, still have %d calls in queue", wait, len(self._requests))
+            self._event.wait(wait)
+
+        else:
+            if __debug__:
+                logger.debug("---- call %s (priority:%d, id:%s)", self._debug_call_name, priority, root_id)
+                debug_call_start = time()
+
+            # call can be either:
+            # 1. a generator
+            # 2. a (callable, args, kargs) tuple
+
+            try:
+                if isinstance(call, TupleType):
+                    # callback
+                    result = call[0](*call[1], **call[2])
+                    if isinstance(result, GeneratorType):
+                        # we only received the generator, no actual call has been made to the
+                        # function yet, therefore we call it again immediately
+                        call = result
+
+                    elif callback:
+                        with self._lock:
+                            heappush(self._expired, (priority, actual_time, root_id, None, (callback[0], (result,) + callback[1], callback[2]), None))
+
+                if isinstance(call, GeneratorType):
+                    # start next generator iteration
+                    result = call.next()
+                    assert isinstance(result, float), [type(result), call]
+                    assert result >= 0.0, [result, call]
+                    with self._lock:
+                        heappush(self._requests, (time() + result, priority, root_id, call, callback))
+
+            except StopIteration:
+                # TODO: found UnboundLocalError bug
+                result = None
+                if callback:
+                    with self._lock:
+                        heappush(self._expired, (priority, actual_time, root_id, None, (callback[0], (result,) + callback[1], callback[2]), None))
+
+            except (SystemExit, KeyboardInterrupt, GeneratorExit) as exception:
+                with self._lock:
+                    self._state = "STATE_EXCEPTION"
+                    self._exception = exception
+                    self._exception_traceback = exc_info()[2]
+                self._call_exception_handlers(exception, True)
+                logger.exception("attempting proper shutdown")
+
+            except Exception as exception:
+                if callback:
+                    with self._lock:
+                        heappush(self._expired, (priority, actual_time, root_id, None, (callback[0], (exception,) + callback[1], callback[2]), None))
+
+                if self._call_exception_handlers(exception, False):
+                    # one or more of the exception handlers returned True, we will consider this
+                    # exception to be fatal and quit
+                    logger.error("reassessing as fatal exception, attempting proper shutdown")
+                    with self._lock:
+                        self._state = "STATE_EXCEPTION"
+                        self._exception = exception
+                        self._exception_traceback = exc_info()[2]
+                else:
+                    logger.exception("keep running regardless of exception")
+
+            if __debug__:
+                debug_call_duration = time() - debug_call_start
+                if debug_call_duration > 1.0:
+                    logger.warning("%.2f call %s (priority:%d, id:%s)", debug_call_duration, self._debug_call_name, priority, root_id)
+                else:
+                    logger.debug("%.2f call %s (priority:%d, id:%s)", debug_call_duration, self._debug_call_name, priority, root_id)
+
+        return True
+
+    @attach_profiler
+    def _loop(self):
+        # from now on we will assume GET_IDENT() is the running thread
         self._thread_ident = get_ident()
 
-        with lock:
+        with self._lock:
             if self._state == "STATE_PLEASE_RUN":
                 self._state = "STATE_RUNNING"
                 logger.debug("STATE_RUNNING")
 
-        while True:
-            actual_time = get_timestamp()
+        # handle tasks as long as possible
+        while self._one_task():
+            pass
 
-            with lock:
-                # check if we should continue to run
-                if self._state != "STATE_RUNNING":
-                    break
-
-                # move expired requests from REQUESTS to EXPIRED
-                while requests and requests[0][0] <= actual_time:
-                    # notice that the deadline and priority entries are switched, hence, the entries in
-                    # the EXPIRED list are ordered by priority instead of deadline
-                    deadline, priority, root_id, call, callback = heappop(requests)
-                    heappush(expired, (priority, deadline, root_id, None, call, callback))
-
-                if expired:
-                    if __debug__ and len(expired) > 10:
-                        if not time_since_expired:
-                            time_since_expired = actual_time
-
-                    # we need to handle the next call in line
-                    priority, deadline, root_id, _, call, callback = heappop(expired)
-                    wait = 0.0
-
-                    if __debug__:
-                        self._debug_call_name = self._debug_call_to_string(call)
-
-                    # ignore removed tasks
-                    if call is None:
-                        continue
-
-                else:
-                    # there is nothing to handle
-                    wait = requests[0][0] - actual_time if requests else 300.0
-                    if __debug__:
-                        logger.debug("nothing to handle, wait %.2f seconds", wait)
-                        if time_since_expired:
-                            diff = actual_time - time_since_expired
-                            if diff > 1.0:
-                                logger.warning("took %.2f to process expired queue", diff)
-                            time_since_expired = 0
-
-                if event_is_set():
-                    event_clear()
-
-            if wait:
-                logger.debug("wait at most %.3fs before next call, still have %d calls in queue", wait, len(requests))
-                event_wait(wait)
-
-            else:
-                if __debug__:
-                    logger.debug("---- call %s (priority:%d, id:%s)", self._debug_call_name, priority, root_id)
-                    debug_call_start = time()
-
-                # call can be either:
-                # 1. a generator
-                # 2. a (callable, args, kargs) tuple
-
-                try:
-                    if isinstance(call, TupleType):
-                        # callback
-                        result = call[0](*call[1], **call[2])
-                        if isinstance(result, GeneratorType):
-                            # we only received the generator, no actual call has been made to the
-                            # function yet, therefore we call it again immediately
-                            call = result
-
-                        elif callback:
-                            with lock:
-                                heappush(expired, (priority, actual_time, root_id, None, (callback[0], (result,) + callback[1], callback[2]), None))
-
-                    if isinstance(call, GeneratorType):
-                        # start next generator iteration
-                        result = call.next()
-                        assert isinstance(result, float), [type(result), call]
-                        assert result >= 0.0, [result, call]
-                        with lock:
-                            heappush(requests, (get_timestamp() + result, priority, root_id, call, callback))
-
-                except StopIteration:
-                    if callback:
-                        with lock:
-                            heappush(expired, (priority, actual_time, root_id, None, (callback[0], (result,) + callback[1], callback[2]), None))
-
-                except (SystemExit, KeyboardInterrupt, GeneratorExit) as exception:
-                    with lock:
-                        self._state = "STATE_EXCEPTION"
-                        self._exception = exception
-                        self._exception_traceback = exc_info()[2]
-                    self._call_exception_handlers(exception, True)
-                    logger.exception("attempting proper shutdown")
-
-                except Exception as exception:
-                    if callback:
-                        with lock:
-                            heappush(expired, (priority, actual_time, root_id, None, (callback[0], (exception,) + callback[1], callback[2]), None))
-
-                    if self._call_exception_handlers(exception, False):
-                        # one or more of the exception handlers returned True, we will consider this
-                        # exception to be fatal and quit
-                        logger.error("reassessing as fatal exception, attempting proper shutdown")
-                        with lock:
-                            self._state = "STATE_EXCEPTION"
-                            self._exception = exception
-                            self._exception_traceback = exc_info()[2]
-                    else:
-                        logger.exception("keep running regardless of exception")
-
-                if __debug__:
-                    debug_call_duration = time() - debug_call_start
-                    if debug_call_duration > 1.0:
-                        logger.warning("%.2f call %s (priority:%d, id:%s)", debug_call_duration, self._debug_call_name, priority, root_id)
-                    else:
-                        logger.debug("%.2f call %s (priority:%d, id:%s)", debug_call_duration, self._debug_call_name, priority, root_id)
-
-        with lock:
+        with self._lock:
             # allowing us to refuse any new tasks.  _requests_mirror and _expired_mirror will still
             # allow tasks to be removed
             self._requests = []
@@ -688,9 +682,9 @@ class Callback(object):
 
         # call all expired tasks and send GeneratorExit exceptions to expired generators, note that
         # new tasks will not be accepted
-        logger.debug("there are %d expired tasks", len(expired))
-        while expired:
-            _, _, _, _, call, callback = heappop(expired)
+        logger.debug("there are %d expired tasks", len(self._expired))
+        while self._expired:
+            _, _, _, _, call, callback = heappop(self._expired)
             if isinstance(call, TupleType):
                 try:
                     result = call[0](*call[1], **call[2])
@@ -723,9 +717,9 @@ class Callback(object):
                         logger.exception("%s", exception)
 
         # send GeneratorExit exceptions to scheduled generators
-        logger.debug("there are %d scheduled tasks", len(requests))
-        while requests:
-            _, _, _, call, callback = heappop(requests)
+        logger.debug("there are %d scheduled tasks", len(self._requests))
+        while self._requests:
+            _, _, _, call, callback = heappop(self._requests)
             if isinstance(call, GeneratorType):
                 logger.debug("raise Shutdown in %s", call)
                 try:
@@ -741,6 +735,6 @@ class Callback(object):
                     logger.exception("%s", exception)
 
         # set state to finished
-        with lock:
+        with self._lock:
             logger.debug("STATE_FINISHED")
             self._state = "STATE_FINISHED"

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -104,3 +104,90 @@ YAPPI:          5x       0.000s /home/boudewijn/svn.tribler.org/abc/branches/mai
 
         while container[0] < 10000:
             yield 1.0
+
+    @call_on_dispersy_thread
+    def test_priority(self):
+        """
+        A generator must retain its priority for every subsequent call.
+        """
+        def generator_func(priority):
+            for _ in xrange(5):
+                container.append("generator_func(%d)" % priority)
+                yield 0.0
+
+        def func(priority):
+            container.append("func(%d)" % priority)
+
+        container = []
+        register = self._dispersy.callback.register
+
+        register(generator_func, (-240,), priority=-240)
+        register(generator_func, (-250,), priority=-250)
+        register(func, (-225,), priority=-225)
+        register(func, (-255,), priority=-255)
+        register(generator_func, (240,), priority=240)
+        register(generator_func, (250,), priority=250)
+        register(func, (235,), priority=235)
+        register(func, (-245,), priority=-245)
+        register(func, (225,), priority=225)
+        register(generator_func, (230,), priority=230)
+        register(generator_func, (-230,), priority=-230)
+        register(func, (255,), priority=255)
+        register(func, (245,), priority=245)
+        register(func, (-235,), priority=-235)
+        self.assertEqual(container, [])
+
+        # wait for a second for all calls to be made
+        yield 1.0
+
+        # we expect:
+        expecting = []
+        expecting.append("func(255)")
+        expecting.extend(["generator_func(250)"] * 5)
+        expecting.append("func(245)")
+        expecting.extend(["generator_func(240)"] * 5)
+        expecting.append("func(235)")
+        expecting.extend(["generator_func(230)"] * 5)
+        expecting.append("func(225)")
+        expecting.append("func(-225)")
+        expecting.extend(["generator_func(-230)"] * 5)
+        expecting.append("func(-235)")
+        expecting.extend(["generator_func(-240)"] * 5)
+        expecting.append("func(-245)")
+        expecting.extend(["generator_func(-250)"] * 5)
+        expecting.append("func(-255)")
+        self.assertEqual(container, expecting)
+
+    @call_on_dispersy_thread
+    def test_call_priority(self):
+        """
+        Using Callback.call on a generator task should still adhere to normal priorities.
+        """
+        def generator_func(priority):
+            for _ in xrange(5):
+                container.append("generator_func(%d)" % priority)
+                self._dispersy.callback.register(func, (0,), priority=0)
+                yield 0.0
+
+        def func(priority):
+            container.append("func(%d)" % priority)
+
+        container = []
+        self._dispersy.callback.call(generator_func, (-128,), priority=-128)
+
+        # wait for a second for all calls to be made
+        yield 1.0
+
+        # we expect:
+        expecting = []
+        expecting.append("generator_func(-128)")
+        expecting.append("func(0)")
+        expecting.append("generator_func(-128)")
+        expecting.append("func(0)")
+        expecting.append("generator_func(-128)")
+        expecting.append("func(0)")
+        expecting.append("generator_func(-128)")
+        expecting.append("func(0)")
+        expecting.append("generator_func(-128)")
+        expecting.append("func(0)")
+        self.assertEqual(container, expecting)

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -10,10 +10,14 @@ def failure_to_success(exception_class, exception_message):
                 func(*args, **kargs)
             except Exception as exception:
                 if isinstance(exception, exception_class) and exception.message == exception_message:
+                    # matches the pre-programmes exception, should not fail
                     return
 
                 # not one of the pre-programmed exceptions, test should indicate failure
                 raise
+
+            # expected an exception, fail
+            raise AssertionError("Expected an exception")
 
         helper2.__name__ = func.__name__
         return helper2
@@ -22,6 +26,12 @@ def failure_to_success(exception_class, exception_message):
 class TestUnittest(DispersyTestFunc):
     """
     Tests ensuring that an exception anywhere in _dispersy.callback is propagated to the unittest framework.
+
+    The 'strict' tests will ensure that any exception results in an early shutdown.  Early shutdown
+    causes the call_on_dispersy_thread generator to receive a Shutdown command, resulting in a
+    RuntimeError("Early shutdown") exception on the caller.
+
+    Non 'strict' tests will result in the Callback ignoring KeyError and AssertionError exceptions.
     """
 
     @failure_to_success(AssertionError, "This must fail")
@@ -29,6 +39,7 @@ class TestUnittest(DispersyTestFunc):
     def test_assert(self):
         " Trivial assert. "
         self.assertTrue(False, "This must fail")
+        self.fail("Should not reach this")
 
     @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
@@ -36,45 +47,98 @@ class TestUnittest(DispersyTestFunc):
         " Trivial KeyError. "
         raise KeyError("This must fail")
 
-    @failure_to_success(AssertionError, "This must fail")
+    @failure_to_success(RuntimeError, "Early shutdown")
     @call_on_dispersy_thread
-    def test_assert_callback(self):
+    def test_assert_strict_callback(self):
         " Assert within a registered task. "
         def task():
             self.assertTrue(False, "This must fail")
+        self.assertTrue(self.enable_strict)
         self._dispersy.callback.register(task)
-        yield 10.0
+        yield 1.0
+        self.fail("Should not reach this")
 
-    @failure_to_success(KeyError, "This must fail")
+    @failure_to_success(RuntimeError, "Early shutdown")
+    @call_on_dispersy_thread
+    def test_KeyError_strict_callback(self):
+        " KeyError within a registered task with strict enabled. "
+        def task():
+            raise KeyError("This must fail")
+        self.assertTrue(self.enable_strict)
+        self._dispersy.callback.register(task)
+        yield 1.0
+        self.fail("Should not reach this")
+
     @call_on_dispersy_thread
     def test_KeyError_callback(self):
         " KeyError within a registered task. "
         def task():
-            raise KeyError("This must fail")
+            raise KeyError("This must be ignored")
+        self.enable_strict = False
         self._dispersy.callback.register(task)
-        yield 10.0
+        yield 1.0
+        self.assertTrue(True)
 
-    @failure_to_success(AssertionError, "This must fail")
+    @failure_to_success(RuntimeError, "Early shutdown")
+    @call_on_dispersy_thread
+    def test_assert_strict_callback_generator(self):
+        " Assert within a registered generator task. "
+        def task():
+            yield 0.1
+            yield 0.1
+            self.assertTrue(False, "This must fail")
+        self.assertTrue(self.enable_strict)
+        self._dispersy.callback.register(task)
+        yield 1.0
+        self.fail("Should not reach this")
+
     @call_on_dispersy_thread
     def test_assert_callback_generator(self):
         " Assert within a registered generator task. "
         def task():
             yield 0.1
             yield 0.1
-            self.assertTrue(False, "This must fail")
+            self.assertTrue(False, "This must be ignored")
+        self.enable_strict = False
         self._dispersy.callback.register(task)
-        yield 10.0
+        yield 1.0
+        self.assertTrue(True)
 
-    @failure_to_success(KeyError, "This must fail")
+    @failure_to_success(RuntimeError, "Early shutdown")
+    @call_on_dispersy_thread
+    def test_KeyError_strict_callback_generator(self):
+        " KeyError within a registered generator task. "
+        def task():
+            yield 0.1
+            yield 0.1
+            raise KeyError("This must fail")
+        self.assertTrue(self.enable_strict)
+        self._dispersy.callback.register(task)
+        yield 1.0
+        self.fail("Should not reach this")
+
     @call_on_dispersy_thread
     def test_KeyError_callback_generator(self):
         " KeyError within a registered generator task. "
         def task():
             yield 0.1
             yield 0.1
-            raise KeyError("This must fail")
+            raise KeyError("This must be ignored")
+        self.enable_strict = False
         self._dispersy.callback.register(task)
-        yield 10.0
+        yield 1.0
+        self.assertTrue(True)
+
+    @failure_to_success(AssertionError, "This must fail")
+    @call_on_dispersy_thread
+    def test_assert_strict_callback_call(self):
+        " Assert within a 'call' task. "
+        def task():
+            self.assertTrue(False, "This must fail")
+        self.assertTrue(self.enable_strict)
+        self._dispersy.callback.call(task)
+        yield 1.0
+        self.fail("Should not reach this")
 
     @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
@@ -82,8 +146,21 @@ class TestUnittest(DispersyTestFunc):
         " Assert within a 'call' task. "
         def task():
             self.assertTrue(False, "This must fail")
+        self.enable_strict = False
         self._dispersy.callback.call(task)
-        yield 10.0
+        yield 1.0
+        self.fail("Should not reach this")
+
+    @failure_to_success(KeyError, "This must fail")
+    @call_on_dispersy_thread
+    def test_KeyError_strict_callback_call(self):
+        " KeyError within a 'call' task. "
+        def task():
+            raise KeyError("This must fail")
+        self.assertTrue(self.enable_strict)
+        self._dispersy.callback.call(task)
+        yield 1.0
+        self.fail("Should not reach this")
 
     @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
@@ -91,8 +168,23 @@ class TestUnittest(DispersyTestFunc):
         " KeyError within a 'call' task. "
         def task():
             raise KeyError("This must fail")
+        self.enable_strict = False
         self._dispersy.callback.call(task)
-        yield 10.0
+        yield 1.0
+        self.fail("Should not reach this")
+
+    @failure_to_success(AssertionError, "This must fail")
+    @call_on_dispersy_thread
+    def test_assert_strict_callback_call_generator(self):
+        " Assert within a 'call' generator task. "
+        def task():
+            yield 0.1
+            yield 0.1
+            self.assertTrue(False, "This must fail")
+        self.assertTrue(self.enable_strict)
+        self._dispersy.callback.call(task)
+        yield 1.0
+        self.fail("Should not reach this")
 
     @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
@@ -102,8 +194,23 @@ class TestUnittest(DispersyTestFunc):
             yield 0.1
             yield 0.1
             self.assertTrue(False, "This must fail")
+        self.enable_strict = False
         self._dispersy.callback.call(task)
-        yield 10.0
+        yield 1.0
+        self.fail("Should not reach this")
+
+    @failure_to_success(KeyError, "This must fail")
+    @call_on_dispersy_thread
+    def test_KeyError_strict_callback_call_generator(self):
+        " KeyError within a 'call' generator task. "
+        def task():
+            yield 0.1
+            yield 0.1
+            raise KeyError("This must fail")
+        self.assertTrue(self.enable_strict)
+        self._dispersy.callback.call(task)
+        yield 1.0
+        self.fail("Should not reach this")
 
     @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
@@ -113,5 +220,7 @@ class TestUnittest(DispersyTestFunc):
             yield 0.1
             yield 0.1
             raise KeyError("This must fail")
+        self.enable_strict = False
         self._dispersy.callback.call(task)
-        yield 10.0
+        yield 1.0
+        self.fail("Should not reach this")


### PR DESCRIPTION
Moving this code allows us to call _one_step whenever a single task
should be executed.  This allows _one_step to be called from the
Callback.call(...) method, fixing the problem with call not being able
to allow other tasks to run when called from the callback thread.  See
the test_call_priority unittest.

This will fix exceptions occurring when Dispersy is running on the
main thread, Dispersy.stop() is called, and packets still arrive.  This
currently happens frequently with DAS experiments.
