### PR TITLE
LAN / WAN detection cleanup

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -9,7 +9,6 @@ if __debug__:
         assert len(address) == 2, len(address)
         assert isinstance(address[0], str), type(address[0])
         assert address[0], address[0]
-        assert not address[0] == "0.0.0.0", address
         assert isinstance(address[1], int), type(address[1])
         assert address[1] >= 0, address[1]
         return True
@@ -54,7 +53,7 @@ class Candidate(object):
         return self._tunnel
 
     def get_destination_address(self, wan_address):
-        assert is_address(wan_address), wan_address
+        logger.debug("deprecated.  use candidate.sock_addr instead")
         return self._sock_addr
 
     def __str__(self):
@@ -120,10 +119,6 @@ class WalkCandidate(Candidate):
     @property
     def connection_type(self):
         return self._connection_type
-
-    def get_destination_address(self, wan_address):
-        assert is_address(wan_address), wan_address
-        return self._lan_address if wan_address[0] == self._wan_address[0] else self._wan_address
 
     def merge(self, other):
         assert isinstance(other, WalkCandidate), type(other)

--- a/community.py
+++ b/community.py
@@ -1401,7 +1401,9 @@ class Community(object):
     def dispersy_on_dynamic_settings(self, messages, initializing=False):
         return self._dispersy.on_dynamic_settings(self, messages, initializing)
 
-    def _iter_category(self, category):
+    def _iter_category(self, category, strict=True):
+        # strict=True will ensure both candidate.lan_address and candidate.wan_address are not
+        # 0.0.0.0:0
         while True:
             index = 0
             has_result = False
@@ -1413,7 +1415,8 @@ class Community(object):
                 candidate = self._candidates.get(key)
 
                 if (candidate and
-                    candidate.get_category(now) == category):
+                    candidate.get_category(now) == category and
+                    not (strict and (candidate.lan_address == ("0.0.0.0", 0) or candidate.wan_address == ("0.0.0.0", 0)))):
 
                     yield candidate
                     has_result = True

--- a/community.py
+++ b/community.py
@@ -1289,22 +1289,24 @@ class Community(object):
         if self._conversions:
             return self._conversions[-1]
 
-        # for backwards compatibility we will raise a KeyError when conversion isn't found (previously self._conversions
-        # was a dictionary)
-        logger.warning("Unable to find default conversion (there are no conversions available)")
+        # for backwards compatibility we will raise a KeyError when conversion isn't found
+        # (previously self._conversions was a dictionary)
+        logger.warning("unable to find default conversion (there are no conversions available)")
         raise KeyError()
 
     def get_conversion_for_packet(self, packet):
         """
         Returns the conversion associated with PACKET.
 
-        This method returns the first available conversion that can *decode* PACKET, this is tested in reversed order
-        using conversion.can_decode_message(PACKET).  Typically a conversion can decode a string when it matches: the
-        community version, the Dispersy version, and the community identifier, and the conversion knows how to decode
-        messages types described in PACKET.
+        This method returns the first available conversion that can *decode* PACKET, this is tested
+        in reversed order using conversion.can_decode_message(PACKET).  Typically a conversion can
+        decode a string when it matches: the community version, the Dispersy version, and the
+        community identifier, and the conversion knows how to decode messages types described in
+        PACKET.
 
-        Note that only the bytes needed to determine conversion.can_decode_message(PACKET) must be given, therefore
-        PACKET is not necessarily an entire packet but can also be a the first N bytes of a packet.
+        Note that only the bytes needed to determine conversion.can_decode_message(PACKET) must be
+        given, therefore PACKET is not necessarily an entire packet but can also be a the first N
+        bytes of a packet.
 
         Raises KeyError(packet) when no conversion is available.
         """
@@ -1313,18 +1315,18 @@ class Community(object):
             if conversion.can_decode_message(packet):
                 return conversion
 
-        # for backwards compatibility we will raise a KeyError when no conversion for PACKET is found (previously
-        # self._conversions was a dictionary)
-        logger.warning("Unable to find conversion to decode %s in %s", packet.encode("HEX"), self._conversions)
+        # for backwards compatibility we will raise a KeyError when no conversion for PACKET is
+        # found (previously self._conversions was a dictionary)
+        logger.warning("unable to find conversion to decode %s in %s", packet.encode("HEX"), self._conversions)
         raise KeyError(packet)
 
     def get_conversion_for_message(self, message):
         """
         Returns the conversion associated with MESSAGE.
 
-        This method returns the first available conversion that can *encode* MESSAGE, this is tested in reversed order
-        using conversion.can_encode_message(MESSAGE).  Typically a conversion can encode a message when: the conversion
-        knows how to encode messages with MESSAGE.name.
+        This method returns the first available conversion that can *encode* MESSAGE, this is tested
+        in reversed order using conversion.can_encode_message(MESSAGE).  Typically a conversion can
+        encode a message when: the conversion knows how to encode messages with MESSAGE.name.
 
         Raises KeyError(message) when no conversion is available.
         """
@@ -1336,9 +1338,9 @@ class Community(object):
             if conversion.can_encode_message(message):
                 return conversion
 
-        # for backwards compatibility we will raise a KeyError when no conversion for MESSAGE is found (previously
-        # self._conversions was a dictionary)
-        logger.warning("Unable to find conversion to encode %s in %s", message, self._conversions)
+        # for backwards compatibility we will raise a KeyError when no conversion for MESSAGE is
+        # found (previously self._conversions was a dictionary)
+        logger.warning("unable to find conversion to encode %s in %s", message, self._conversions)
         raise KeyError(message)
 
     def add_conversion(self, conversion):

--- a/community.py
+++ b/community.py
@@ -1740,7 +1740,9 @@ class Community(object):
         for other in others:
             # all except for the CANDIDATE
             if not other == candidate:
-                logger.warn("removing %s in favor of %s", other, candidate)
+                logger.warning("removing %s %s in favor of %s %s",
+                               other.sock_addr, other,
+                               candidate.sock_addr, candidate)
                 candidate.merge(other)
                 del self._candidates[other.sock_addr]
                 self.add_candidate(candidate)

--- a/community.py
+++ b/community.py
@@ -1689,9 +1689,6 @@ class Community(object):
         else:
             # modify either the senders LAN or WAN address based on how we perceive that node
             source_lan_address, source_wan_address = self._dispersy.estimate_lan_and_wan_addresses(message.candidate.sock_addr, message.payload.source_lan_address, message.payload.source_wan_address)
-            if source_lan_address == ("0.0.0.0", 0) or source_wan_address == ("0.0.0.0", 0):
-                logger.debug("problems determining source LAN or WAN address, can neither introduce nor convert candidate to WalkCandidate")
-                return None
 
             # check if we have this candidate registered at its sock_addr
             candidate = self.get_candidate(message.candidate.sock_addr, lan_address=source_lan_address)

--- a/dispersy.py
+++ b/dispersy.py
@@ -2201,23 +2201,30 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
         """
         assert self.is_valid_address(sock_addr), sock_addr
 
+        # TODO Below are a few 'info' level logs, they should become 'debug' level once this code is
+        # stable.
+
         if any(sock_addr[0] in interface for interface in self._local_interfaces):
             # is SOCK_ADDR is on our local LAN, hence LAN_ADDRESS should be SOCK_ADDR
             if sock_addr != lan_address:
-                logger.warning("estimate someones LAN address is %s:%d (LAN was %s:%d, WAN stays %s:%d)",
-                               sock_addr[0], sock_addr[1], lan_address[0], lan_address[1], wan_address[0], wan_address[1])
+                logger.info("estimate someones LAN address is %s:%d (LAN was %s:%d, WAN stays %s:%d)",
+                            sock_addr[0], sock_addr[1], lan_address[0], lan_address[1], wan_address[0], wan_address[1])
                 lan_address = sock_addr
 
+            # it is possible that the WAN address that someone claims to have is correct, while the
+            # WAN address that we believe we have is not.  it is not a problem to have candidates
+            # with the same WAN address as us
+            #
             # any WAN address is acceptable except when it matches our WAN address
-            if wan_address == self.wan_address:
-                logger.warning("cleared someones WAN address %s:%d (this is our WAN address)", wan_address[0], wan_address[1])
-                wan_address = ("0.0.0.0", 0)
+            # if wan_address == self.wan_address:
+            #     logger.info("cleared someones WAN address %s:%d (this is our WAN address)", wan_address[0], wan_address[1])
+            #     wan_address = ("0.0.0.0", 0)
 
         else:
             # is SOCK_ADDR is outside our local LAN, hence WAN_ADDRESS should be SOCK_ADDR
             if sock_addr != wan_address:
-                logger.warning("estimate someones WAN address is %s:%d (WAN was %s:%d, LAN stays %s:%d)",
-                               sock_addr[0], sock_addr[1], wan_address[0], wan_address[1], lan_address[0], lan_address[1])
+                logger.info("estimate someones WAN address is %s:%d (WAN was %s:%d, LAN stays %s:%d)",
+                            sock_addr[0], sock_addr[1], wan_address[0], wan_address[1], lan_address[0], lan_address[1])
                 wan_address = sock_addr
 
         return lan_address, wan_address

--- a/dispersy.py
+++ b/dispersy.py
@@ -1113,6 +1113,7 @@ class Dispersy(object):
                 set_wan_address(address):
 
             # reassessing our LAN address, perhaps we are running on a roaming device
+            self._local_interfaces = list(self._get_interface_addresses())
             interface = self._guess_lan_address(self._local_interfaces)
             lan_address = ((interface.address if interface else "0.0.0.0"), self._lan_address[1])
             if not self.is_valid_address(lan_address):

--- a/endpoint.py
+++ b/endpoint.py
@@ -277,6 +277,15 @@ class StandaloneEndpoint(RawserverEndpoint):
         if timeout > 0.0:
             self._thread.join(timeout)
 
+            if self._thread.is_alive():
+                logger.error("the endpoint thread is still running (after waiting %f seconds)", timeout)
+                result = False
+
+        else:
+            if self._thread.is_alive():
+                logger.debug("the endpoint thread is still running (use timeout > 0.0 to ensure the thread stops)")
+                result = False
+
         try:
             self._socket.close()
         except socket.error as exception:

--- a/endpoint.py
+++ b/endpoint.py
@@ -165,10 +165,10 @@ class RawserverEndpoint(Endpoint):
     def send(self, candidates, packets):
         assert self._dispersy, "Should not be called before open(...)"
         assert isinstance(candidates, (tuple, list, set)), type(candidates)
-        assert all(isinstance(candidate, Candidate) for candidate in candidates)
+        assert all(isinstance(candidate, Candidate) for candidate in candidates), [type(candidate) for candidate in candidates]
         assert isinstance(packets, (tuple, list, set)), type(packets)
-        assert all(isinstance(packet, str) for packet in packets)
-        assert all(len(packet) > 0 for packet in packets)
+        assert all(isinstance(packet, str) for packet in packets), [type(packet) for packet in packets]
+        assert all(len(packet) > 0 for packet in packets), [len(packet) for packet in packets]
         if any(len(packet) > 2**16 - 60 for packet in packets):
             raise RuntimeError("UDP does not support %d byte packets" % len(max(len(packet) for packet in packets)))
 

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -115,6 +115,9 @@ class TestOverlay(DispersyTestFunc):
             info.candidate_success = self._dispersy.statistics.walk_success - self._dispersy.statistics.walk_bootstrap_success
             info.candidate_ratio = 100.0 * info.candidate_success / info.candidate_attempt if info.candidate_attempt else 0.0
             info.incoming_walks = self._dispersy.statistics.walk_advice_incoming_request
+            info.lan_address = self._dispersy.lan_address
+            info.wan_address = self._dispersy.wan_address
+            info.connection_type = self._dispersy.connection_type
             history.append(info)
 
             summary.info("after %.1f seconds there are %d verified candidates [w%d:s%d:i%d:n%d]",
@@ -160,9 +163,9 @@ class TestOverlay(DispersyTestFunc):
 
         # write graph statistics
         with open("%s_connections.txt" % cid_hex, "w+") as handle:
-            handle.write("TIME VERIFIED_CANDIDATES WALK_CANDIDATES STUMBLE_CANDIDATES INTRO_CANDIDATES NONE_CANDIDATES B_ATTEMPTS B_SUCCESSES C_ATTEMPTS C_SUCCESSES INCOMING_WALKS\n")
+            handle.write("TIME VERIFIED_CANDIDATES WALK_CANDIDATES STUMBLE_CANDIDATES INTRO_CANDIDATES NONE_CANDIDATES B_ATTEMPTS B_SUCCESSES C_ATTEMPTS C_SUCCESSES INCOMING_WALKS LAN_ADDRESS WAN_ADDRESS CONNECTION_TYPE\n")
             for info in history:
-                handle.write("%f   %d   %d   %d   %d   %d   %d   %d   %d   %d   %d\n" % (
+                handle.write("%f   %d   %d   %d   %d   %d   %d   %d   %d   %d   %d   %s   %s   \"%s\"\n" % (
                         info.diff,
                         len(info.verified_candidates),
                         len([_ for _, category in info.candidates if category == u"walk"]),
@@ -173,7 +176,10 @@ class TestOverlay(DispersyTestFunc):
                         info.bootstrap_success,
                         info.candidate_attempt,
                         info.candidate_success,
-                        info.incoming_walks))
+                        info.incoming_walks,
+                        "%s:%d" % info.lan_address,
+                        "%s:%d" % info.wan_address,
+                        info.connection_type))
 
         average_verified_candidates = 1.0 * sum(len(info.verified_candidates) for info in history) / len(history)
         average_walk_candidates = 1.0 * sum(len([_ for _, category in info.candidates if category == u"walk"]) for info in history) / len(history)
@@ -187,8 +193,8 @@ class TestOverlay(DispersyTestFunc):
             info = history[-1]
             import socket
 
-            handle.write("TIMESTAMP HOSTNAME CID_HEX AVG_VERIFIED_CANDIDATES AVG_WALK_CANDIDATES AVG_STUMBLE_CANDIDATES AVG_INTRO_CANDIDATES AVG_NONE_CANDIDATES B_ATTEMPTS B_SUCCESSES C_ATTEMPTS C_SUCCESSES INCOMING_WALKS\n")
-            handle.write("%f \"%s\" %s %f %f %f %f %f %d %d %d %d %d\n" % (
+            handle.write("TIMESTAMP HOSTNAME CID_HEX AVG_VERIFIED_CANDIDATES AVG_WALK_CANDIDATES AVG_STUMBLE_CANDIDATES AVG_INTRO_CANDIDATES AVG_NONE_CANDIDATES B_ATTEMPTS B_SUCCESSES C_ATTEMPTS C_SUCCESSES INCOMING_WALKS LAN_ADDRESS WAN_ADDRESS CONNECTION_TYPE\n")
+            handle.write("%f \"%s\" %s %f %f %f %f %f %d %d %d %d %d %s %s \"%s\"\n" % (
                     time(),
                     socket.gethostname(),
                     cid_hex,
@@ -201,7 +207,10 @@ class TestOverlay(DispersyTestFunc):
                     info.bootstrap_success,
                     info.candidate_attempt,
                     info.candidate_success,
-                    info.incoming_walks))
+                    info.incoming_walks,
+                    "%s:%d" % info.lan_address,
+                    "%s:%d" % info.wan_address,
+                    info.connection_type))
 
         # determine test success or failure (hard coded for 10.0 or higher being a success)
         summary.debug("Average verified candidates: %.1f", average_verified_candidates)

--- a/tool/ldecoder.py
+++ b/tool/ldecoder.py
@@ -340,6 +340,21 @@ class Parser(object):
         if self.verbose:
             print "#", self.progress, self.filename, "->", lineno, "lines"
 
+    def parse_file(self, filename, bzip2=False, unknown=False):
+        parser = bz2parse if bzip2 else parse
+        interests = () if unknown else set(self.mapping.keys())
+        unknown = [self.unknown]
+
+        self.start_parser(filename)
+        lineno = 0
+        try:
+            for lineno, timestamp, name, kargs in parser(filename, interests):
+                for func in self.mapping.get(name, unknown):
+                    func(timestamp, name, **kargs)
+        except NextFile:
+            pass
+        self.stop_parser(lineno)
+
     def parse_directory(self, directory, filename, bzip2=False, unknown=False):
         parser = bz2parse if bzip2 else parse
         interests = () if unknown else set(self.mapping.keys())

--- a/tool/scenarioscript.py
+++ b/tool/scenarioscript.py
@@ -382,7 +382,7 @@ if poisson:
             self.__poisson_online_mu = float(online_mu)
             self.__poisson_offline_mu = float(offline_mu)
             self.log("scenario-poisson-churn", online_mu=self.__poisson_online_mu, offline_mu=self.__poisson_offline_mu)
-            self._dispersy.callback.persistent_register("scenario-poisson-identifier", self.__poisson_churn)
+            self._dispersy.callback.persistent_register(u"scenario-poisson-identifier", self.__poisson_churn)
 
 if expon:
     class ScenarioExpon(object):
@@ -421,7 +421,7 @@ if expon:
             self.__expon_min_offline = float("5.0" if min_offline == "DEF" else min_offline)
             self.__expon_max_offline = float(maxsize if max_offline == "DEF" else max_offline)
             self.log("scenario-expon-churn", online_beta=self.__expon_online_beta, offline_beta=self.__expon_offline_beta, online_threshold=self.__expon_online_threshold, min_online=self.__expon_min_online, max_online=self.__expon_max_online, offline_threshold=self.__expon_offline_threshold, min_offline=self.__expon_min_offline, max_offline=self.__expon_max_offline)
-            self._dispersy.callback.persistent_register("scenario-expon-identifier", self.__expon_churn)
+            self._dispersy.callback.persistent_register(u"scenario-expon-identifier", self.__expon_churn)
 
 class ScenarioUniform(object):
     def __init__(self, *args, **kargs):
@@ -451,7 +451,7 @@ class ScenarioUniform(object):
         self.__uniform_offline_low = offline_mean * (1.0 - offline_mod)
         self.__uniform_offline_high = offline_mean * (1.0 + offline_mod)
         self.log("scenario-uniform-churn", online_low=self.__uniform_online_low, online_high=self.__uniform_online_high, offline_low=self.__uniform_offline_low, offline_high=self.__uniform_offline_high)
-        self._dispersy.callback.persistent_register("scenario-uniform-identifier", self.__uniform_churn)
+        self._dispersy.callback.persistent_register(u"scenario-uniform-identifier", self.__uniform_churn)
 
 class ScenarioPredefined(object):
     """


### PR DESCRIPTION
Below is a list with the changes, all other commits contain bug fixes, cleanup, and unit tests.

The performance/behavior of peers on the DAS 2 (see: http://jenkins.tribler.org/job/Test_community_walking_NAT) does not appear to change.

Fixes a bug on the DAS4 where very rarely peers are unable to send messages to each other.
- Dispersy._local_interfaces contains a list with all available
  interfaces, including their subnet mask
- Votes for our WAN address that originate from within our LAN are
  ignored.  A vote originates from within our LAN when the origin
  sock_addr matches any of Dispersy._local_interfaces, taking into
  account the subnet mask of each interface.
- Dispersy.estimate_lan_and_wan_addresses has been simplified.  It now
  recognises the inability to determine the WAN address of someone who
  is on its LAN address (or the LAN address of someone who is on its WAN
  address).
- Candidate.lan_address and Candidate.wan_address is now allowed to
  be (0.0.0.0, 0).  Previously the value would always be set to -some-
  address, sometimes resulting in incorrect addresses.
- Candidate.sock_addr is always used when sending packets to a
  Candidate.  The Candidate.get_destination_address method is
  deprecated.
