### PR TITLE
Blocking gethostbyname

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,100 +1,158 @@
-from os import path
 from socket import gethostbyname
-from threading import Thread, Lock, Event
+from threading import Lock, Event
+from random import shuffle
 
+from .callback import Callback
 from .candidate import BootstrapCandidate
 from .logger import get_logger
 logger = get_logger(__name__)
 
-_trackers = [(u"dispersy1.tribler.org", 6421),
-             (u"dispersy2.tribler.org", 6422),
-             (u"dispersy3.tribler.org", 6423),
-             (u"dispersy4.tribler.org", 6424),
-             (u"dispersy5.tribler.org", 6425),
-             (u"dispersy6.tribler.org", 6426),
-             (u"dispersy7.tribler.org", 6427),
-             (u"dispersy8.tribler.org", 6428),
+_DEFAULT_ADDRESSES = ((u"dispersy1.tribler.org", 6421),
+                      (u"dispersy2.tribler.org", 6422),
+                      (u"dispersy3.tribler.org", 6423),
+                      (u"dispersy4.tribler.org", 6424),
+                      (u"dispersy5.tribler.org", 6425),
+                      (u"dispersy6.tribler.org", 6426),
+                      (u"dispersy7.tribler.org", 6427),
+                      (u"dispersy8.tribler.org", 6428),
 
-             (u"dispersy1b.tribler.org", 6421),
-             (u"dispersy2b.tribler.org", 6422),
-             (u"dispersy3b.tribler.org", 6423),
-             (u"dispersy4b.tribler.org", 6424),
-             (u"dispersy5b.tribler.org", 6425),
-             (u"dispersy6b.tribler.org", 6426),
-             (u"dispersy7b.tribler.org", 6427),
-             (u"dispersy8b.tribler.org", 6428)]
-
-
-def get_bootstrap_hosts(working_directory):
-    """
-    Reads WORKING_DIRECTORY/bootstraptribler.txt and returns the hosts therein, otherwise it
-    returns _TRACKERS.
-    """
-    trackers = []
-    filename = path.join(working_directory, "bootstraptribler.txt")
-    try:
-        for line in open(filename, "r"):
-            line = line.strip()
-            if not line.startswith("#"):
-                host, port = line.split()
-                trackers.append((host.decode("UTF-8"), int(port)))
-    except:
-        pass
-
-    if trackers:
-        return trackers
-    else:
-        return _trackers
+                      (u"dispersy1b.tribler.org", 6421),
+                      (u"dispersy2b.tribler.org", 6422),
+                      (u"dispersy3b.tribler.org", 6423),
+                      (u"dispersy4b.tribler.org", 6424),
+                      (u"dispersy5b.tribler.org", 6425),
+                      (u"dispersy6b.tribler.org", 6426),
+                      (u"dispersy7b.tribler.org", 6427),
+                      (u"dispersy8b.tribler.org", 6428))
 
 
-def get_bootstrap_candidates(dispersy, timeout=1.0):
-    """
-    Returns a list with all known bootstrap peers.
+class Bootstrap(object):
 
-    Bootstrap peers are retrieved from WORKING_DIRECTORY/bootstraptribler.txt if it exits.
-    Otherwise it is created using the trackers defined in _TRACKERS.
+    @staticmethod
+    def load_addresses_from_file(filename):
+        """
+        Reads FILENAME and returns the hosts therein, otherwise returns an empty list.
+        """
+        addresses = []
+        try:
+            for line in open(filename, "r"):
+                line = line.strip()
+                if not line.startswith("#"):
+                    host, port = line.split()
+                    addresses.append((host.decode("UTF-8"), int(port)))
+        except:
+            pass
 
-    Each bootstrap peer gives either None or a Candidate.  None values can be caused by
-    malfunctioning DNS.
-    """
-    assert isinstance(timeout, float), type(timeout)
-    assert timeout > 0.0, timeout
+        return addresses
 
-    def gethostbyname_in_parallel():
-        for host, port in hosts:
+    @staticmethod
+    def get_default_addresses():
+        return _DEFAULT_ADDRESSES
+
+    def __init__(self, callback, addresses):
+        assert isinstance(callback, Callback), type(callback)
+        assert isinstance(addresses, (tuple, list)), type(addresses)
+        self._callback = callback
+        self._lock = Lock()
+        self._candidates = dict((address, None) for address in addresses)
+        self._thread_counter = 0
+
+    @property
+    def are_resolved(self):
+        """
+        Returns True when all addresses are resolved.
+
+        Note: this method is thread safe.
+        """
+        with self._lock:
+            return all(self._candidates.itervalues())
+
+    @property
+    def candidates(self):
+        """
+        Returns all *resolved* BootstrapCandidate instances.
+
+        Note: this method is thread safe.
+        """
+        with self._lock:
+            return [candidate for candidate in self._candidates.itervalues() if candidate]
+
+    @property
+    def progress(self):
+        """
+        Returns a (resolved_count, total_count) tuple.
+
+        Note: this method is thread safe.
+        """
+        with self._lock:
+            return (len([candidate for candidate in self._candidates.itervalues() if candidate]),
+                    len(self._candidates))
+
+    def reset(self):
+        """
+        Removes all previously resolved addresses.
+
+        Note: this method is thread safe.
+        """
+        with self._lock:
+            self._candidates = dict((address, None) for address in self._candidates.iterkeys())
+
+    def resolve(self, func, timeout=60.0):
+        """
+        Resolve all unresolved trackers on a separate thread.
+
+        FUNC is called on the self._callback thread when either:
+        1. all trackers are resolved (with True as the first parameter), or
+        2. after TIMEOUT seconds (with False as the first parameter).
+
+        Note: this method is thread safe.
+        """
+        assert isinstance(timeout, float), type(timeout)
+        assert timeout > 0.0, timeout
+
+        if self.are_resolved:
+            self._callback.register(func, (True,))
+
+        else:
+            self._thread_counter += 1
+
+            # start a new thread (using Callback to ensure the thread is named properly)
+            thread = Callback("Get-Bootstrap-Candidates-%d" % self._thread_counter)
+            thread.register(self._gethostbyname_in_parallel, (func, timeout))
+            thread.register(thread.stop)
+            thread.start()
+
+    def _gethostbyname_in_parallel(self, func, timeout):
+        def on_timeout():
+            # cancel
+            event.set()
+
+            # report failure
+            self._callback.register(func, (False,))
+
+        event = Event()
+        success = True
+        on_timeout_id = self._callback.register(on_timeout, delay=timeout)
+
+        with self._lock:
+            addresses = [address for address, candidate in self._candidates.iteritems() if not candidate]
+            shuffle(addresses)
+
+        for host, port in addresses:
             if event.is_set():
                 # timeout
                 break
 
             try:
                 candidate = BootstrapCandidate((gethostbyname(host), port), False)
+                logger.debug("resolved %s into %s", host, candidate)
+
+                with self._lock:
+                    self._candidates[(host, port)] = candidate
 
             except:
                 logger.exception("unable to obtain BootstrapCandidate(%s, %d)", host, port)
-                candidate = None
-
-            with lock:
-                results.append(candidate)
+                success = False
 
         # indicate results are ready
-        event.set()
-
-    lock = Lock()
-    event = Event()
-    results = []
-    hosts = get_bootstrap_hosts(dispersy.working_directory)
-    logger.debug("obtaining %d BootstrapCandidates", len(hosts))
-
-    # start thread
-    thread = Thread(target=gethostbyname_in_parallel, name="Get-Bootstrap-Candidates")
-    thread.damon = True
-    thread.start()
-
-    # wait for results
-    event.wait(timeout)
-    event.set()
-
-    # return results
-    with lock:
-        logger.debug("returning %d/%d BootstrapCandidates", len([result for result in results if result]), len(hosts))
-        return results[:]
+        self._callback.replace_register(on_timeout_id, func, (success,))

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -25,6 +25,8 @@ _DEFAULT_ADDRESSES = ((u"dispersy1.tribler.org", 6421),
                       (u"dispersy7b.tribler.org", 6427),
                       (u"dispersy8b.tribler.org", 6428))
 
+# _DEFAULT_ADDRESSES = _DEFAULT_ADDRESSES + tuple((u"rotten.dns.entry%d.org" % i, 1234) for i in xrange(8))
+
 
 class Bootstrap(object):
 

--- a/callback.py
+++ b/callback.py
@@ -204,7 +204,7 @@ class Callback(object):
                 if exception_handler(exception, fatal):
                     force_fatal = True
             except Exception as exception:
-                logger.exception("%s", exception)
+                logger.exception("%s in %s", exception, exception_handler)
                 assert False, "the exception handler should not cause an exception"
 
         if fatal or force_fatal:
@@ -213,17 +213,16 @@ class Callback(object):
                 self._exception = exception
                 self._exception_traceback = exc_info()[2]
 
-
             if fatal:
-                logger.exception("attempting proper shutdown [%s]", exception)
+                logger.warning("attempting proper shutdown [%s]", exception)
 
             else:
                 # one or more of the exception handlers returned True, we will consider this
                 # exception to be fatal and quit
-                logger.exception("reassessing as fatal exception, attempting proper shutdown [%s]", exception)
+                logger.warning("reassessing as fatal exception, attempting proper shutdown [%s]", exception)
 
         else:
-            logger.exception("keep running regardless of exception [%s]", exception)
+            logger.warning("keep running regardless of exception [%s]", exception)
 
         return fatal
 

--- a/callback.py
+++ b/callback.py
@@ -9,6 +9,12 @@ from time import sleep, time
 from types import GeneratorType, TupleType
 from sys import exc_info
 
+try:
+    from prctl import set_name
+except ImportError:
+    def set_name(_):
+        pass
+
 from .decorator import attach_profiler
 from .logger import get_logger
 logger = get_logger(__name__)
@@ -670,6 +676,9 @@ class Callback(object):
 
     @attach_profiler
     def loop(self):
+        # set thread name (visible from ps and top)
+        set_name(self._name[:16])
+
         # from now on we will assume GET_IDENT() is the running thread
         self._thread_ident = get_ident()
 

--- a/callback.py
+++ b/callback.py
@@ -121,9 +121,12 @@ class Callback(object):
 
         if __debug__:
             def must_close(callback):
-                assert callback.is_finished
+                assert callback.is_finished, self
             atexit_register(must_close, self)
             self._debug_call_name = None
+
+    def __str__(self):
+        return "<%s %s %d>" % (self.__class__.__name__, self._name, self._thread_ident)
 
     @property
     def ident(self):
@@ -390,19 +393,19 @@ class Callback(object):
         assert isinstance(callback_args, tuple), "CALLBACK_ARGS has invalid type: %s" % type(callback_args)
         assert callback_kargs is None or isinstance(callback_kargs, dict), "CALLBACK_KARGS has invalid type: %s" % type(callback_kargs)
         assert isinstance(include_id, bool), "INCLUDE_ID has invalid type: %d" % type(include_id)
-        logger.debug("replace register %s after %.2f seconds", call, delay)
+        logger.debug("replace register %s after %.2f seconds (priority:%d, id:%s)", call, delay, priority, id_)
 
         with self._lock:
             # un-register
             for index, tup in enumerate(self._requests_mirror):
                 if tup[2] == id_:
                     self._requests_mirror[index] = (tup[0], tup[1], id_, None, None)
-                    logger.debug("in _requests: %s", id_)
+                    logger.debug("unregistered %s from _requests", id_)
 
             for index, tup in enumerate(self._expired_mirror):
                 if tup[2] == id_:
                     self._expired_mirror[index] = (tup[0], tup[1], id_, None, None)
-                    logger.debug("in _expired: %s", id_)
+                    logger.debug("unregistered %s from _expired", id_)
 
             # register
             if delay <= 0.0:
@@ -439,12 +442,12 @@ class Callback(object):
             for index, tup in enumerate(self._requests_mirror):
                 if tup[2] == id_:
                     self._requests_mirror[index] = (tup[0], tup[1], id_, None, None)
-                    logger.debug("in _requests: %s", id_)
+                    logger.debug("unregistered %s from _requests", id_)
 
             for index, tup in enumerate(self._expired_mirror):
                 if tup[2] == id_:
                     self._expired_mirror[index] = (tup[0], tup[1], id_, None, None)
-                    logger.debug("in _expired: %s", id_)
+                    logger.debug("unregistered %s from _expired", id_)
 
     def call(self, call, args=(), kargs=None, delay=0.0, priority=0, id_=u"", include_id=False, timeout=0.0, default=None):
         """

--- a/community.py
+++ b/community.py
@@ -1648,6 +1648,17 @@ class Community(object):
                 self._candidates[candidate.sock_addr] = candidate
                 self._dispersy.statistics.total_candidates_discovered += 1
 
+    def update_bootstrap_candidates(self, candidates):
+        """
+        Informs the community that BootstrapCandidate instances are available.
+
+        This method will ensure that none of the self._candidates point to a known
+        BootstrapCandidate.
+        """
+        for candidate in candidates:
+            self._candidates.pop(candidate.sock_addr, None)
+        assert candidate.sock_addr not in self._dispersy._bootstrap_candidates.iterkeys(), "none of the bootstrap candidates may be in self._candidates"
+
     def get_candidate_mid(self, mid):
         members = self._dispersy.get_members_from_id(mid)
         if members:

--- a/community.py
+++ b/community.py
@@ -1659,7 +1659,9 @@ class Community(object):
         """
         for candidate in candidates:
             self._candidates.pop(candidate.sock_addr, None)
-        assert candidate.sock_addr not in self._dispersy._bootstrap_candidates.iterkeys(), "none of the bootstrap candidates may be in self._candidates"
+
+        assert len(set(self._candidates.iterkeys()) & set(bsc.sock_addr for bsc in self._dispersy.bootstrap_candidates)) == 0,\
+                   "candidates and bootstrap candidates must be separate"
 
     def get_candidate_mid(self, mid):
         members = self._dispersy.get_members_from_id(mid)

--- a/decorator.py
+++ b/decorator.py
@@ -64,6 +64,7 @@ if "--profiler" in getattr(sys, "argv", []):
             finally:
                 logger.debug("profiler results [%s]", filename)
                 profiler.dump_stats(filename)
+                _profiled_threads.remove(filename)
 
         return helper
 

--- a/dispersy.py
+++ b/dispersy.py
@@ -463,7 +463,7 @@ class Dispersy(object):
                 logger.debug("resolved all bootstrap addresses")
 
             else:
-                delay = 30.0 if container["attempt_counter"] < 30 else 300.0
+                delay = 0.0 if container["attempt_counter"] == 1 else 300.0
                 logger.warning("unable to resolve all bootstrap addresses.  waiting %.1fs before next attempt (attempt #%d)",
                                container["attempt_counter"], delay)
                 self._callback.register(retry, delay=delay)
@@ -474,7 +474,7 @@ class Dispersy(object):
 
         def retry():
             container["attempt_counter"] += 1
-            timeout = 10.0 if container["attempt_counter"] else 300.0
+            timeout = 1.0 if container["attempt_counter"] == 1 else 300.0
             logger.debug("resolving bootstrap addresses (%.1s timeout)", timeout)
             bootstrap.resolve(on_results, timeout)
 
@@ -4491,7 +4491,10 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         assert timeout >= 0.0, timeout
 
         def bootstrap_progress(_, resolved, total):
-            if resolved == total:
+            # we are happy starting with just 50% of the available BootstrapCandidates,
+            # i.e. Dispersy will still start quickly, even if a small subset of the addresses no
+            # longer resolves
+            if resolved >= total * 0.5:
                 event.set()
 
         def start():

--- a/dispersy.py
+++ b/dispersy.py
@@ -53,11 +53,13 @@ from hashlib import sha1
 from itertools import groupby, islice, count
 from pprint import pformat
 from socket import inet_aton, error as socket_error
+from struct import unpack_from
+from threading import Event
 from time import time
 
 from .authentication import NoAuthentication, MemberAuthentication, DoubleMemberAuthentication
 from .bloomfilter import BloomFilter
-from .bootstrap import get_bootstrap_candidates
+from .bootstrap import Bootstrap
 from .candidate import BootstrapCandidate, LoopbackCandidate, WalkCandidate, Candidate
 from .crypto import ec_generate_key, ec_to_public_bin, ec_to_private_bin
 from .destination import CommunityDestination, CandidateDestination
@@ -333,10 +335,7 @@ class Dispersy(object):
         logger.debug("my connection type is %s", self._connection_type)
 
         # bootstrap peers
-        bootstrap_candidates = get_bootstrap_candidates(self)
-        if not all(bootstrap_candidates):
-            self._callback.register(self._retry_bootstrap_candidates)
-        self._bootstrap_candidates = dict((candidate.sock_addr, candidate) for candidate in bootstrap_candidates if candidate)
+        self._bootstrap_candidates = dict()
 
         # communities that can be auto loaded.  classification:(cls, args, kargs) pairs.
         self._auto_load_communities = OrderedDict()
@@ -396,13 +395,14 @@ class Dispersy(object):
         logger.error("Unable to find our public interface!")
         return None
 
-    def _retry_bootstrap_candidates(self):
+    def _resolve_bootstrap_candidates(self, func):
         """
-        One or more bootstrap addresses could not be retrieved.
+        Resolve bootstrap candidates.
 
-        The first 30 seconds we will attempt to resolve the addresses once every second.  If we did
-        not succeed after 30 seconds will will retry once every 30 seconds until we succeed.
+        FUNC(attempt_counter, resolved, total) is called periodically until all addresses are
+        resolved.
         """
+<<<<<<< Updated upstream
         logger.warning("unable to resolve all bootstrap addresses")
         for counter in count(1):
             yield 1.0 if counter < 30 else 30.0
@@ -412,9 +412,48 @@ class Dispersy(object):
                 if candidate is None:
                     break
             else:
+=======
+        assert self._callback.is_current_thread
+        assert callable(func)
+
+        def on_results(success):
+            assert self._callback.is_current_thread
+            assert isinstance(success, bool), type(success)
+
+            # even when success is False it is still possible that *some* addresses were resolved
+            self._bootstrap_candidates.update((candidate.sock_addr, candidate) for candidate in bootstrap.candidates)
+            logger.debug("there are %d available bootstrap candidates", len(self._bootstrap_candidates))
+
+            # ensure none of the current candidates in Community._candidates point to bootstrap
+            # candidates
+            for community in self._communities.itervalues():
+                community.update_bootstrap_candidates(self._bootstrap_candidates.itervalues())
+
+            if success:
+>>>>>>> Stashed changes
                 logger.debug("resolved all bootstrap addresses")
-                self._bootstrap_candidates = dict((candidate.sock_addr, candidate) for candidate in candidates if candidate)
-                break
+
+            else:
+                delay = 30.0 if container["attempt_counter"] < 30 else 300.0
+                logger.warning("unable to resolve all bootstrap addresses.  waiting %.1fs before next attempt (attempt #%d)",
+                               container["attempt_counter"], delay)
+                self._callback.register(retry, delay=delay)
+
+            # feedback
+            resolved, total = bootstrap.progress
+            func(container["attempt_counter"], resolved, total)
+
+        def retry():
+            container["attempt_counter"] += 1
+            timeout = 10.0 if container["attempt_counter"] else 300.0
+            logger.debug("resolving bootstrap addresses (%.1s timeout)", timeout)
+            bootstrap.resolve(on_results, timeout)
+
+        container = {"attempt_counter":0}
+        alternate_addresses = Bootstrap.load_addresses_from_file(os.path.join(self._working_directory, "bootstraptribler.txt"))
+        default_addresses = Bootstrap.get_default_addresses()
+        bootstrap = Bootstrap(self._callback, alternate_addresses or default_addresses)
+        retry()
 
     @property
     def working_directory(self):
@@ -4410,21 +4449,31 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         """
         self._database.commit()
 
-    def start(self):
+    def start(self, timeout=10.0):
         """
         Starts Dispersy.
 
         This method is thread safe.
 
         1. starts callback
-        2. opens database
-        3. opens endpoint
+        2. resolve bootstrap candidates (done in parallel)
+        3. opens database
+        4. opens endpoint
         """
 
         assert not self._callback.is_running, "Must be called before callback.start()"
+        assert isinstance(timeout, float), type(timeout)
+        assert timeout >= 0.0, timeout
+
+        def bootstrap_progress(_, resolved, total):
+            if resolved == total:
+                event.set()
 
         def start():
             assert self._callback.is_current_thread, "Must be called from the callback thread"
+
+            # resolving the bootstrap candidates is performed in parallel
+            self._resolve_bootstrap_candidates(bootstrap_progress)
 
             results.append((u"database", self._database.open()))
             assert all(isinstance(result, bool) for _, result in results), [type(result) for _, result in results]
@@ -4435,12 +4484,18 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
 
         # start
         logger.info("starting the Dispersy core...")
+        event = Event()
         results = []
 
         results.append((u"callback", self._callback.start()))
         assert all(isinstance(result, bool) for _, result in results), [type(result) for _, result in results]
 
         self._callback.call(start, priority=512)
+
+        # wait until bootstrap progress reports that the addresses have been resolved
+        event.wait(timeout)
+        results.append((u"resolve-bootstrap", event.is_set()))
+        assert all(isinstance(result, bool) for _, result in results), [type(result) for _, result in results]
 
         # log and return the result
         if all(result for _, result in results):

--- a/dispersy.py
+++ b/dispersy.py
@@ -4524,10 +4524,12 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
 
         self._callback.call(start, priority=512)
 
-        # wait until bootstrap progress reports that the addresses have been resolved
-        event.wait(timeout)
-        results.append((u"resolve-bootstrap", event.is_set()))
-        assert all(isinstance(result, bool) for _, result in results), [type(result) for _, result in results]
+        # blocking is not an option when we are running on the same thread
+        if not self._callback.is_current_thread:
+            # wait until bootstrap progress reports that the addresses have been resolved
+            event.wait(timeout)
+            results.append((u"resolve-bootstrap", event.is_set()))
+            assert all(isinstance(result, bool) for _, result in results), [type(result) for _, result in results]
 
         # log and return the result
         if all(result for _, result in results):

--- a/tests/dispersytestclass.py
+++ b/tests/dispersytestclass.py
@@ -28,7 +28,7 @@ class DispersyTestFunc(TestCase):
     """
 
     def on_callback_exception(self, exception, is_fatal):
-        logger.debug("%s (fatal: %s, strict: %s)", exception, is_fatal, self.enable_strict)
+        logger.exception("%s (fatal: %s, strict: %s)", exception, is_fatal, self.enable_strict)
 
         if self.enable_strict and self._dispersy:
             self._dispersy.stop()

--- a/tool/main.py
+++ b/tool/main.py
@@ -71,7 +71,7 @@ def main_real(setup=None):
 
     # setup callback
     def exception_handler(exception, fatal):
-        logger.error("An exception occurred.  Quitting because we are running with --strict enabled.")
+        logger.exception("An exception occurred.  Quitting because we are running with --strict enabled.")
         # return fatal=True
         return True
     callback = MainThreadCallback("Dispersy")


### PR DESCRIPTION
The addresses of BootstrapCandidate instances are resolved on a separate thread, on success or timeout a callback is performed.

The goal is to ensure Tribler doesn't block when the dns resolving is having problems (slow or unresponsive dns servers, or simply an address that is no longer valid).  However, for the Tribler search community to work correctly the 'fast bootstrap' must have bootstrap candidates.  Therefore the Dispersy.start() will block at most timeout=10 seconds until 50% of the bootstrap servers are resolved.

Note that Dispersy will keep trying to resolve (between 300 and 600 seconds intervals, depending on the failure reason) until it has resolved all addresses.  Once an address is resolved it is not resolved again.
