### PR TITLE
Exceptions that are raised should not be logged.

### DIFF
--- a/database.py
+++ b/database.py
@@ -306,13 +306,8 @@ class Database(object):
         assert isinstance(bindings, (tuple, list, dict, set)), "The bindings must be a tuple, list, dictionary, or set"
         assert all(lambda x: isinstance(x, str) for x in bindings), "The bindings may not contain a string. \nProvide unicode for TEXT and buffer(...) for BLOB. \nGiven types: %s" % str([type(binding) for binding in bindings])
 
-        try:
-            logger.log(logging.NOTSET, "%s <-- %s [%s]", statement, bindings, self._file_path)
-            return self._cursor.execute(statement, bindings)
-
-        except Error:
-            logger.exception("%s [%s] ", statement, self._file_path)
-            raise
+        logger.log(logging.NOTSET, "%s <-- %s [%s]", statement, bindings, self._file_path)
+        return self._cursor.execute(statement, bindings)
 
     @attach_runtime_statistics("{0.__class__.__name__}.{function_name} {1} [{0.file_path}]")
     def executescript(self, statements):
@@ -322,13 +317,8 @@ class Database(object):
         assert self._debug_thread_ident == thread.get_ident(), "Calling Database.execute on the wrong thread"
         assert isinstance(statements, unicode), "The SQL statement must be given in unicode"
 
-        try:
-            logger.log(logging.NOTSET, "%s [%s]", statements, self._file_path)
-            return self._cursor.executescript(statements)
-
-        except Error:
-            logger.exception("%s [%s]", statements, self._file_path)
-            raise
+        logger.log(logging.NOTSET, "%s [%s]", statements, self._file_path)
+        return self._cursor.executescript(statements)
 
     @attach_explain_query_plan
     @attach_runtime_statistics("{0.__class__.__name__}.{function_name} {1} [{0.file_path}]")
@@ -375,13 +365,8 @@ class Database(object):
             if is_iterator:
                 sequenceofbindings = iter(sequenceofbindings)
 
-        try:
-            logger.log(logging.NOTSET, "%s [%s]", statement, self._file_path)
-            return self._cursor.executemany(statement, sequenceofbindings)
-
-        except Error:
-            logger.exception("%s [%s]", statement, self._file_path)
-            raise
+        logger.log(logging.NOTSET, "%s [%s]", statement, self._file_path)
+        return self._cursor.executemany(statement, sequenceofbindings)
 
     @attach_runtime_statistics("{0.__class__.__name__}.{function_name} [{0.file_path}]")
     def commit(self, exiting=False):
@@ -453,13 +438,8 @@ class APSWDatabase(Database):
         assert isinstance(bindings, (tuple, list, dict)), "The bindings must be a tuple, list, or dictionary"
         assert all(lambda x: isinstance(x, str) for x in bindings), "The bindings may not contain a string. \nProvide unicode for TEXT and buffer(...) for BLOB. \nGiven types: %s" % str([type(binding) for binding in bindings])
 
-        try:
-            logger.log(logging.NOTSET, "%s <-- %s [%s]", statement, bindings, self._file_path)
-            return self._cursor.execute(statement, bindings)
-
-        except apsw.Error:
-            logger.exception("%s [%s]", statement, self._file_path)
-            raise
+        logger.log(logging.NOTSET, "%s <-- %s [%s]", statement, bindings, self._file_path)
+        return self._cursor.execute(statement, bindings)
 
     def executescript(self, statements):
         return self.execute(statements)
@@ -479,13 +459,8 @@ class APSWDatabase(Database):
         assert all(isinstance(x, (tuple, list, dict)) for x in list(sequenceofbindings)), "The sequenceofbindings must be a list with tuples, lists, or dictionaries"
         assert not filter(lambda x: filter(lambda y: isinstance(y, str), x), list(sequenceofbindings)), "The bindings may not contain a string. \nProvide unicode for TEXT and buffer(...) for BLOB."
 
-        try:
-            logger.log(logging.NOTSET, "%s [%s]", statement, self._file_path)
-            return self._cursor.executemany(statement, sequenceofbindings)
-
-        except apsw.Error:
-            logger.exception("%s [%s]", statement, self._file_path)
-            raise
+        logger.log(logging.NOTSET, "%s [%s]", statement, self._file_path)
+        return self._cursor.executemany(statement, sequenceofbindings)
 
     @property
     def last_insert_rowid(self):


### PR DESCRIPTION
This will allow people to ignore statements that they know can fail.

See #152
