### PR TITLE
Fixes API inconsistency.

### DIFF
--- a/crypto.py
+++ b/crypto.py
@@ -157,6 +157,7 @@ def ec_sign(ec, digest):
     """
     Returns the signature of DIGEST made using EC.
     """
+    assert isinstance(digest, str), type(digest)
     length = int(ceil(len(ec) / 8.0))
 
     mpi_r, mpi_s = ec.sign_dsa(digest)
@@ -171,6 +172,8 @@ def ec_verify(ec, digest, signature):
     """
     Returns True when SIGNATURE matches the DIGEST made using EC.
     """
+    assert isinstance(digest, str), type(digest)
+    assert isinstance(signature, str), type(signature)
     assert len(signature) == ec_signature_length(ec), [len(signature), ec_signature_length(ec)]
     length = len(signature) / 2
     try:

--- a/tests/test_member.py
+++ b/tests/test_member.py
@@ -1,7 +1,9 @@
+from hashlib import sha1
+
+from ..crypto import ec_generate_key, ec_sign, ec_verify, ec_to_public_bin, ec_to_private_bin
 from .debugcommunity.community import DebugCommunity
 from .debugcommunity.node import DebugNode
 from .dispersytestclass import DispersyTestFunc, call_on_dispersy_thread
-
 
 class TestMemberTag(DispersyTestFunc):
 
@@ -101,3 +103,126 @@ class TestMemberTag(DispersyTestFunc):
         # cleanup
         community.create_dispersy_destroy_community(u"hard-kill")
         self._dispersy.get_community(community.cid).unload_community()
+
+
+class TestMember(DispersyTestFunc):
+
+    @call_on_dispersy_thread
+    def test_verify(self):
+        """
+        Test test member.verify assuming ec_sign works properly.
+        """
+        ec = ec_generate_key(u"medium")
+        member = self._dispersy.get_member(ec_to_public_bin(ec), ec_to_private_bin(ec))
+
+        # sign and verify "0123456789"[0:10]
+        self.assertTrue(member.verify("0123456789", ec_sign(ec, sha1("0123456789").digest())))
+        self.assertTrue(member.verify("0123456789", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=0))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=0))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=9))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=9))
+        self.assertTrue(member.verify("0123456789", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=10))
+        self.assertTrue(member.verify("0123456789E", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=10))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=11))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=11))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=666))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("0123456789").digest()), offset=0, length=666))
+
+        # sign and verify "0123456789"[1:10]
+        self.assertTrue(member.verify("123456789", ec_sign(ec, sha1("123456789").digest())))
+        self.assertTrue(member.verify("0123456789", ec_sign(ec, sha1("123456789").digest()), offset=1, length=0))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("123456789").digest()), offset=1, length=0))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("123456789").digest()), offset=1, length=8))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("123456789").digest()), offset=1, length=8))
+        self.assertTrue(member.verify("0123456789", ec_sign(ec, sha1("123456789").digest()), offset=1, length=9))
+        self.assertTrue(member.verify("0123456789E", ec_sign(ec, sha1("123456789").digest()), offset=1, length=9))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("123456789").digest()), offset=1, length=10))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("123456789").digest()), offset=1, length=10))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("123456789").digest()), offset=1, length=666))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("123456789").digest()), offset=1, length=666))
+
+        # sign and verify "0123456789"[0:9]
+        self.assertTrue(member.verify("012345678", ec_sign(ec, sha1("012345678").digest())))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("012345678").digest()), offset=0, length=0))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("012345678").digest()), offset=0, length=0))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("012345678").digest()), offset=0, length=8))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("012345678").digest()), offset=0, length=8))
+        self.assertTrue(member.verify("0123456789", ec_sign(ec, sha1("012345678").digest()), offset=0, length=9))
+        self.assertTrue(member.verify("0123456789E", ec_sign(ec, sha1("012345678").digest()), offset=0, length=9))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("012345678").digest()), offset=0, length=10))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("012345678").digest()), offset=0, length=10))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("012345678").digest()), offset=0, length=666))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("012345678").digest()), offset=0, length=666))
+
+        # sign and verify "0123456789"[1:9]
+        self.assertTrue(member.verify("12345678", ec_sign(ec, sha1("12345678").digest())))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("12345678").digest()), offset=1, length=0))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("12345678").digest()), offset=1, length=0))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("12345678").digest()), offset=1, length=7))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("12345678").digest()), offset=1, length=7))
+        self.assertTrue(member.verify("0123456789", ec_sign(ec, sha1("12345678").digest()), offset=1, length=8))
+        self.assertTrue(member.verify("0123456789E", ec_sign(ec, sha1("12345678").digest()), offset=1, length=8))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("12345678").digest()), offset=1, length=9))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("12345678").digest()), offset=1, length=9))
+        self.assertFalse(member.verify("0123456789", ec_sign(ec, sha1("12345678").digest()), offset=1, length=666))
+        self.assertFalse(member.verify("0123456789E", ec_sign(ec, sha1("12345678").digest()), offset=1, length=666))
+
+    @call_on_dispersy_thread
+    def test_sign(self):
+        """
+        Test test member.sign assuming ec_verify works properly.
+        """
+        ec = ec_generate_key(u"medium")
+        member = self._dispersy.get_member(ec_to_public_bin(ec), ec_to_private_bin(ec))
+
+        # sign and verify "0123456789"[0:10]
+        self.assertTrue(ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789")))
+        self.assertTrue(ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789", offset=0, length=0)))
+        self.assertFalse(ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789E", offset=0, length=0)))
+        self.assertFalse(ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789", offset=0, length=9)))
+        self.assertFalse(ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789E", offset=0, length=9)))
+        self.assertTrue(ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789", offset=0, length=10)))
+        self.assertTrue(ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789E", offset=0, length=10)))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789", offset=0, length=11))
+        self.assertFalse(ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789E", offset=0, length=11)))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789", offset=0, length=666))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("0123456789").digest(), member.sign("0123456789E", offset=0, length=666))
+
+        # sign and verify "0123456789"[1:10]
+        self.assertTrue(ec_verify(ec, sha1("123456789").digest(), member.sign("123456789")))
+        self.assertTrue(ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789", offset=1, length=0)))
+        self.assertFalse(ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789E", offset=1, length=0)))
+        self.assertFalse(ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789", offset=1, length=8)))
+        self.assertFalse(ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789E", offset=1, length=8)))
+        self.assertTrue(ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789", offset=1, length=9)))
+        self.assertTrue(ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789E", offset=1, length=9)))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789", offset=1, length=10))
+        self.assertFalse(ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789E", offset=1, length=10)))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789", offset=1, length=666))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("123456789").digest(), member.sign("0123456789E", offset=1, length=666))
+
+        # sign and verify "0123456789"[0:9]
+        self.assertTrue(ec_verify(ec, sha1("012345678").digest(), member.sign("012345678")))
+        self.assertFalse(ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789", offset=0, length=0)))
+        self.assertFalse(ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789E", offset=0, length=0)))
+        self.assertFalse(ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789", offset=0, length=8)))
+        self.assertFalse(ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789E", offset=0, length=8)))
+        self.assertTrue(ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789", offset=0, length=9)))
+        self.assertTrue(ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789E", offset=0, length=9)))
+        self.assertFalse(ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789", offset=0, length=10)))
+        self.assertFalse(ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789E", offset=0, length=10)))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789", offset=0, length=666))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("012345678").digest(), member.sign("0123456789E", offset=0, length=666))
+
+        # sign and verify "0123456789"[1:9]
+        self.assertTrue(ec_verify(ec, sha1("12345678").digest(), member.sign("12345678")))
+        self.assertFalse(ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789", offset=1, length=0)))
+        self.assertFalse(ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789E", offset=1, length=0)))
+        self.assertFalse(ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789", offset=1, length=7)))
+        self.assertFalse(ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789E", offset=1, length=7)))
+        self.assertTrue(ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789", offset=1, length=8)))
+        self.assertTrue(ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789E", offset=1, length=8)))
+        self.assertFalse(ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789", offset=1, length=9)))
+        self.assertFalse(ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789E", offset=1, length=9)))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789", offset=1, length=666))
+        with self.assertRaises(ValueError): ec_verify(ec, sha1("12345678").digest(), member.sign("0123456789E", offset=1, length=666))


### PR DESCRIPTION
Member.sign and Member.verify used the OFFSET and LENGTH parameters
differently.  They now both use the one Member.verify used, i.e. LENGTH
is the number of bytes, starting at offset, that is either verified or
signed.

In addition to this change, whenever there is insufficient DATA
available, i.e. len(DATA) < OFFSET + LENGTH, then Member.verify will
return False and Member.sign will raise a ValueError.
