### PR TITLE
Externalized sql query for Bloomfilters, Introduced NoDefBinaryConversion

### DIFF
--- a/callback.py
+++ b/callback.py
@@ -300,7 +300,7 @@ class Callback(object):
             else:
                 heappush(self._requests,
                          (delay + time(),
-                          -priority,
+                          - priority,
                           id_,
                           (call, args + (id_,) if include_id else args, {} if kargs is None else kargs),
                           None if callback is None else (callback, callback_args, {} if callback_kargs is None else callback_kargs)))
@@ -363,7 +363,7 @@ class Callback(object):
                     else:
                         heappush(self._requests,
                                  (delay + time(),
-                                  -priority,
+                                  - priority,
                                   id_,
                                   (call, args + (id_,) if include_id else args, {} if kargs is None else kargs),
                                   None if callback is None else (callback, callback_args, {} if callback_kargs is None else callback_kargs)))
@@ -418,7 +418,7 @@ class Callback(object):
             else:
                 heappush(self._requests,
                          (delay + time(),
-                          -priority,
+                          - priority,
                           id_,
                           (call, args + (id_,) if include_id else args, {} if kargs is None else kargs),
                           None if callback is None else (callback, callback_args, {} if callback_kargs is None else callback_kargs)))
@@ -661,6 +661,9 @@ class Callback(object):
                 self._call_exception_handlers(exception, True)
 
             except Exception as exception:
+                from traceback import print_exc
+                print_exc()
+
                 if callback:
                     with self._lock:
                         heappush(self._expired, (priority, actual_time, root_id, (callback[0], (exception,) + callback[1], callback[2]), None))

--- a/callback.py
+++ b/callback.py
@@ -661,9 +661,6 @@ class Callback(object):
                 self._call_exception_handlers(exception, True)
 
             except Exception as exception:
-                from traceback import print_exc
-                print_exc()
-
                 if callback:
                     with self._lock:
                         heappush(self._expired, (priority, actual_time, root_id, (callback[0], (exception,) + callback[1], callback[2]), None))

--- a/community.py
+++ b/community.py
@@ -1644,6 +1644,7 @@ class Community(object):
 
     def add_candidate(self, candidate):
         if not isinstance(candidate, BootstrapCandidate):
+            assert isinstance(candidate, WalkCandidate), type(candidate)
             assert candidate.sock_addr not in self._dispersy._bootstrap_candidates.iterkeys(), "none of the bootstrap candidates may be in self._candidates"
 
             if candidate.sock_addr not in self._candidates:

--- a/conversion.py
+++ b/conversion.py
@@ -1405,7 +1405,7 @@ class NoDefBinaryConversion(Conversion):
     def __str__(self):
         return "<%s %s%s [%s]>" % (self.__class__.__name__, self.dispersy_version.encode("HEX"), self.community_version.encode("HEX"), ", ".join(self._encode_message_map.iterkeys()))
 
-class BinaryConversion(StructConversion):
+class BinaryConversion(NoDefBinaryConversion):
 
     """
     Extends NoDefBinaryConversion and will define all standard dispersy messages

--- a/conversion.py
+++ b/conversion.py
@@ -184,7 +184,7 @@ class NoDefBinaryConversion(Conversion):
             self.destination = destination
             self.payload = payload
 
-    def __init__(self, community, commnity_version):
+    def __init__(self, community, community_version):
         Conversion.__init__(self, community, "\x00", community_version)
 
         self._struct_B = Struct(">B")

--- a/conversion.py
+++ b/conversion.py
@@ -1412,7 +1412,7 @@ class BinaryConversion(NoDefBinaryConversion):
     """
 
     def __init__(self, community, community_version):
-        NoDefBinaryConversion.__init__(self, community, "\x00", community_version)
+        NoDefBinaryConversion.__init__(self, community, community_version)
 
         def define(value, name, encode, decode):
             try:

--- a/conversion.py
+++ b/conversion.py
@@ -1412,7 +1412,7 @@ class BinaryConversion(NoDefBinaryConversion):
     """
 
     def __init__(self, community, community_version):
-        super(BinaryConversion).__init__(community, community_version)
+        super(BinaryConversion, self).__init__(community, community_version)
 
         def define(value, name, encode, decode):
             try:

--- a/conversion.py
+++ b/conversion.py
@@ -1412,7 +1412,7 @@ class BinaryConversion(NoDefBinaryConversion):
     """
 
     def __init__(self, community, community_version):
-        NoDefBinaryConversion.__init__(self, community, community_version)
+        super(BinaryConversion).__init__(community, community_version)
 
         def define(value, name, encode, decode):
             try:

--- a/dispersy.py
+++ b/dispersy.py
@@ -2513,6 +2513,20 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
                     self._endpoint.send([message.candidate], packets)
 
     def _get_packets_for_bloomfilters(self, community, requests, include_inactive=True):
+        """
+        Return all packets matching a Bloomfilter request
+        
+        @param community: The community wherein all requests were received
+        @type messages: [Community]
+
+        @param request: A list of requests, each of them being a tuple consisting of the request,
+         time_low, time_high, offset, and modulo  
+        @type request: list 
+
+        @param include_inactive: When False only active packets (due to pruning) are returned 
+        @type include_inactive: bool
+        """
+
         assert isinstance(requests, list)
         assert all(isinstance(request, (list, tuple)) for request in requests)
         assert all(len(request) == 5 for request in requests)

--- a/dispersy.py
+++ b/dispersy.py
@@ -2251,12 +2251,9 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
 
                     # verify that the bloom filter is correct
                     try:
-                        packets = [str(packet) for packet, in self._database.execute(u"""
-SELECT sync.packet
-FROM sync
-JOIN meta_message ON meta_message.id = sync.meta_message
-WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND global_time BETWEEN ? AND ? AND (sync.global_time + ?) % ? = 0""",
-                                                                                     (community.database_id, time_low, community.global_time if time_high == 0 else time_high, offset, modulo))]
+                        _, packets = self._get_packets_for_bloomfilters([[None, time_low, community.global_time if time_high == 0 else time_high, offset, modulo]], include_inactive=True).next()
+                        packets = list(packets)
+
                     except OverflowError:
                         logger.error("time_low:  %d", time_low)
                         logger.error("time_high: %d", time_high)
@@ -2405,6 +2402,42 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         #
         # process the bloom filter part of the request
         #
+        messages_with_sync = []
+        for message in messages:
+            payload = message.payload
+
+            if payload.sync:
+                # 07/05/12 Boudewijn: for an unknown reason values larger than 2^63-1 cause
+                # overflow exceptions in the sqlite3 wrapper
+                time_low = min(payload.time_low, 2 ** 63 - 1)
+                time_high = min(payload.time_high if payload.has_time_high else community.global_time, 2 ** 63 - 1)
+
+                offset = long(payload.offset)
+                modulo = long(payload.modulo)
+
+                messages_with_sync.append((message, time_low, time_high, offset, modulo))
+
+        for message, generator in self._get_packets_for_bloomfilters(messages_with_sync, include_inactive=False):
+            # we limit the response by byte_limit bytes
+            byte_limit = community.dispersy_sync_response_limit
+
+            packets = []
+            for packet, in payload.bloom_filter.not_filter(generator):
+                packets.append(packet)
+                byte_limit -= len(packet)
+                if byte_limit <= 0:
+                    logger.debug("bandwidth throttle")
+                    break
+
+            if packets:
+                logger.debug("syncing %d packets (%d bytes) to %s", len(packets), sum(len(packet) for packet in packets), message.candidate)
+                self._statistics.dict_inc(self._statistics.outgoing, u"-sync-", len(packets))
+                self._endpoint.send([message.candidate], packets)
+
+    def _get_packets_for_bloomfilters(self, requests, include_inactive=True):
+        assert isinstance(requests, list)
+        assert all(isinstance(list, tuple) for request in requests)
+        assert all(len(request) == 5 for request in requests)
 
         def get_sub_select(meta):
             direction = meta.distribution.synchronization_direction
@@ -2442,42 +2475,19 @@ WHERE sync.community = ? AND meta_message.priority > 32 AND sync.undone = 0 AND 
         sql = "".join((u"SELECT * FROM (", " UNION ALL ".join(get_sub_select(meta) for meta in meta_messages), ")"))
         logger.debug(sql)
 
-        for message in messages:
-            payload = message.payload
+        for message, time_low, time_high, offset, modulo in requests:
+            sql_arguments = []
+            for meta in meta_messages:
+                if include_inactive:
+                    _time_low = time_low
+                else:
+                    _time_low = min(max(time_low, community.global_time - meta.distribution.pruning.inactive_threshold + 1), 2 ** 63 - 1) if isinstance(meta.distribution.pruning, GlobalTimePruning) else time_low
 
-            if payload.sync:
-                # we limit the response by byte_limit bytes
-                byte_limit = community.dispersy_sync_response_limit
-                time_high = payload.time_high if payload.has_time_high else community.global_time
+                sql_arguments.extend((meta.database_id, _time_low, time_high, offset, modulo))
+            logger.debug("%s", sql_arguments)
 
-                # 07/05/12 Boudewijn: for an unknown reason values larger than 2^63-1 cause
-                # overflow exceptions in the sqlite3 wrapper
-                # 26/02/13 Boudewijn: time_low and time_high must now be given once for every
-                # sub_selects, taking into account that time_low may not be below the
-                # inactive_threshold (if given)
-                sql_arguments = []
-                for meta in meta_messages:
-                    sql_arguments.extend((meta.database_id,
-                                          min(max(payload.time_low, community.global_time - meta.distribution.pruning.inactive_threshold + 1), 2 ** 63 - 1) if isinstance(meta.distribution.pruning, GlobalTimePruning) else min(payload.time_low, 2 ** 63 - 1),
-                                          min(time_high, 2 ** 63 - 1),
-                                          long(payload.offset),
-                                          long(payload.modulo)))
-                logger.debug("%s", sql_arguments)
-
-                packets = []
-                generator = ((str(packet),) for packet, in self._database.execute(sql, sql_arguments))
-
-                for packet, in payload.bloom_filter.not_filter(generator):
-                    packets.append(packet)
-                    byte_limit -= len(packet)
-                    if byte_limit <= 0:
-                        logger.debug("bandwidth throttle")
-                        break
-
-                if packets:
-                    logger.debug("syncing %d packets (%d bytes) to %s", len(packets), sum(len(packet) for packet in packets), message.candidate)
-                    self._statistics.dict_inc(self._statistics.outgoing, u"-sync-", len(packets))
-                    self._endpoint.send([message.candidate], packets)
+            packets = []
+            yield message, ((str(packet),) for packet, in self._database.execute(sql, sql_arguments))
 
     def check_introduction_response(self, messages):
         for message in messages:

--- a/dispersy.py
+++ b/dispersy.py
@@ -2514,7 +2514,7 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
 
     def _get_packets_for_bloomfilters(self, community, requests, include_inactive=True):
         assert isinstance(requests, list)
-        assert all(isinstance(list, tuple) for request in requests)
+        assert all(isinstance(request, (list, tuple)) for request in requests)
         assert all(len(request) == 5 for request in requests)
 
         def get_sub_select(meta):

--- a/dispersy.py
+++ b/dispersy.py
@@ -2526,7 +2526,7 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
         @param include_inactive: When False only active packets (due to pruning) are returned 
         @type include_inactive: bool
         
-        @return: An interator yielding the original request and an interator consisting of the packet matching the request
+        @return: An generator yielding the original request and a generator consisting of the packets matching the request
         """
 
         assert isinstance(requests, list)

--- a/dispersy.py
+++ b/dispersy.py
@@ -2415,7 +2415,7 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
                 offset = long(payload.offset)
                 modulo = long(payload.modulo)
 
-                messages_with_sync.append((community, message, time_low, time_high, offset, modulo))
+                messages_with_sync.append((message, time_low, time_high, offset, modulo))
 
         if messages_with_sync:
             for message, generator in self._get_packets_for_bloomfilters(community, messages_with_sync, include_inactive=False):

--- a/dispersy.py
+++ b/dispersy.py
@@ -2517,10 +2517,6 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
         assert all(isinstance(list, tuple) for request in requests)
         assert all(len(request) == 5 for request in requests)
 
-        if not any(message.payload.sync for message in messages):
-            # no sync needed
-            return
-
         def get_sub_select(meta):
             direction = meta.distribution.synchronization_direction
             if direction == u"ASC":

--- a/dispersy.py
+++ b/dispersy.py
@@ -2409,6 +2409,9 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
             if payload.sync:
                 # 07/05/12 Boudewijn: for an unknown reason values larger than 2^63-1 cause
                 # overflow exceptions in the sqlite3 wrapper
+                
+                # 11/11/13 Niels: according to http://www.sqlite.org/datatype3.html integers are signed and max
+                # 8 bytes, hence the max value is 2 ** 63 - 1 as one bit is used for the sign
                 time_low = min(payload.time_low, 2 ** 63 - 1)
                 time_high = min(payload.time_high if payload.has_time_high else community.global_time, 2 ** 63 - 1)
 

--- a/dispersy.py
+++ b/dispersy.py
@@ -2519,12 +2519,14 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
         @param community: The community wherein all requests were received
         @type messages: [Community]
 
-        @param request: A list of requests, each of them being a tuple consisting of the request,
+        @param requests: A list of requests, each of them being a tuple consisting of the request,
          time_low, time_high, offset, and modulo  
-        @type request: list 
+        @type requests: list 
 
         @param include_inactive: When False only active packets (due to pruning) are returned 
         @type include_inactive: bool
+        
+        @return: An interator yielding the original request and an interator consisting of the packet matching the request
         """
 
         assert isinstance(requests, list)

--- a/requestcache.py
+++ b/requestcache.py
@@ -181,7 +181,8 @@ class RequestCache(object):
         if cache.cleanup_delay:
             self._callback.replace_register(cache.identifier, self._on_cleanup, (cache,), delay=cache.cleanup_delay)
 
-        else:
+        # the on_timeout call could have already removed the identifier from the cache using pop
+        elif cache.identifier in self._identifiers:
             del self._identifiers[cache.identifier]
 
     def _on_cleanup(self, cache):
@@ -201,5 +202,8 @@ class RequestCache(object):
 
         logger.debug("cleanup on %s", cache)
         cache.on_cleanup()
-        del self._identifiers[cache.identifier]
+
+        # the on_cleanup call could have already removed the identifier from the cache using pop
+        if cache.identifier in self._identifiers:
+            del self._identifiers[cache.identifier]
 


### PR DESCRIPTION
- The new externalized sql query handling a Bloomfilter allows a developer to determine which packets should be tested against an incomming Bloomfilter.
- The NoDefBinaryConversion allows a developer to extend a conversion object which does not define all default Dispersy messages. Usefull when you want to only define a couple messages in a conversion object and let other conversion classes to overwrite any of the default Dispersy messages.
