### PR TITLE
Replace candidate instead of setting a new sock_addr, this way the

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -44,10 +44,6 @@ class Candidate(object):
     def sock_addr(self):
         return self._sock_addr
 
-    @sock_addr.setter
-    def sock_addr(self, sock_addr):
-        self._sock_addr = sock_addr
-
     @property
     def tunnel(self):
         return self._tunnel
@@ -73,6 +69,8 @@ class Candidate(object):
         """
         return not (isinstance(other, Candidate) and self._sock_addr == other.sock_addr)
 
+    def __hash__(self):
+        return hash(str(self._sock_addr))
 
 class WalkCandidate(Candidate):
 

--- a/community.py
+++ b/community.py
@@ -1619,10 +1619,7 @@ class Community(object):
                         # replace candidate
                         del self._candidates[candidate.sock_addr]
                         lan_address, wan_address = self._dispersy.estimate_lan_and_wan_addresses(sock_addr, candidate.lan_address, candidate.wan_address)
-                        candidate.sock_addr = sock_addr
-                        candidate.update(candidate.tunnel, lan_address, wan_address, candidate.connection_type)
-                        self._candidates[candidate.sock_addr] = candidate
-
+                        self._candidates[candidate.sock_addr] = candidate = self.create_candidate(sock_addr, candidate.tunnel, lan_address, wan_address, candidate.connection_type)
                     break
 
             else:


### PR DESCRIPTION
**hash**() return value will never change for the same object.
Remove sock_addr setter as it shouldn't be modified once the Candidate
has been created.
