### PR TITLE
Pass optional arguments to create_number.

### DIFF
--- a/requestcache.py
+++ b/requestcache.py
@@ -83,7 +83,7 @@ class NumberCache(Cache):
     def __init__(self, request_cache, *create_identifier_args):
         # find an unclaimed identifier
         while True:
-            number = self.create_number()
+            number = self.create_number(*create_identifier_args)
             identifier = self.create_identifier(number, *create_identifier_args)
             if not request_cache.has(identifier):
                 super(NumberCache, self).__init__(identifier)


### PR DESCRIPTION
We must support the use case where the optional arguments can contain an
alternative number that should be used instead of the generated one.
