### PR TITLE
Simplifies Dispersy.stop.

### DIFF
--- a/dispersy.py
+++ b/dispersy.py
@@ -4648,9 +4648,6 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
             results = {u"callback":None, u"community":None, u"endpoint":None, u"database":None}
             results[u"callback"] = self._callback.stop(timeout, final_func=stop)
 
-            if not self._callback.is_current_thread:
-                self._callback.join(timeout)
-
             # log and return the result
             if all(result for result in results.itervalues()):
                 logger.info("Dispersy core properly stopped")

--- a/tests/dispersytestclass.py
+++ b/tests/dispersytestclass.py
@@ -16,10 +16,15 @@ def call_on_dispersy_thread(func):
 
 class DispersyTestFunc(TestCase):
 
+    # every Dispersy instance gets its own Callback thread with its own number.  this is useful in
+    # some debugging scenarios.
+    _thread_counter = 0
+
     """
     Setup and tear down Dispersy before and after each test method.
 
     setUp will ensure the following members exists before each test method is called:
+    - self._callback
     - self._dispersy
     - self._my_member
     - self._enable_strict
@@ -28,9 +33,7 @@ class DispersyTestFunc(TestCase):
     """
 
     def on_callback_exception(self, exception, is_fatal):
-        logger.exception("%s (fatal: %s, strict: %s)", exception, is_fatal, self.enable_strict)
-
-        if self.enable_strict and self._dispersy:
+        if self.enable_strict and self._dispersy and self._dispersy.callback.is_running:
             self._dispersy.stop()
             self._dispersy = None
 
@@ -51,21 +54,30 @@ class DispersyTestFunc(TestCase):
         logger.debug("setUp")
 
         self._enable_strict = True
-        callback = Callback("Dispersy-Unit-Test")
-        callback.attach_exception_handler(self.on_callback_exception)
+        DispersyTestFunc._thread_counter += 1
+        self._callback = Callback("Test-%d" % (self._thread_counter,))
+        self._callback.attach_exception_handler(self.on_callback_exception)
         endpoint = StandaloneEndpoint(12345)
         working_directory = u"."
         database_filename = u":memory:"
 
-        self._dispersy = Dispersy(callback, endpoint, working_directory, database_filename)
+        self._dispersy = Dispersy(self._callback, endpoint, working_directory, database_filename)
         self._dispersy.start()
-        self._my_member = callback.call(self._dispersy.get_new_member, (u"low",))
+        self._my_member = self._callback.call(self._dispersy.get_new_member, (u"low",))
 
     def tearDown(self):
         super(DispersyTestFunc, self).tearDown()
         logger.debug("tearDown")
 
-        if self._dispersy:
-            self.assertTrue(self._dispersy.stop())
-            self._dispersy = None
+        if self._dispersy and self._callback.is_running:
+            self.assertTrue(self._dispersy.stop(10.0))
+
+        else:
+            # Dispersy was stopped because an exception occurred, hence Dispersy.stop was called
+            # from its own thread which doesn't allow Dispersy.stop to wait until its thread is
+            # closed.
+            self.assertTrue(self._callback.join(10.0))
+
+        self._callback = None
+        self._dispersy = None
         self._my_member = None

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -26,10 +26,6 @@ class TestUnittest(DispersyTestFunc):
     """
     Tests ensuring that an exception anywhere in _dispersy.callback is propagated to the unittest framework.
 
-    The 'strict' tests will ensure that any exception results in an early shutdown.  Early shutdown
-    causes the call_on_dispersy_thread generator to receive a Shutdown command, resulting in a
-    RuntimeError("Early shutdown") exception on the caller.
-
     Non 'strict' tests will result in the Callback ignoring KeyError and AssertionError exceptions.
     """
 
@@ -46,7 +42,7 @@ class TestUnittest(DispersyTestFunc):
         " Trivial KeyError. "
         raise KeyError("This must fail")
 
-    @failure_to_success(RuntimeError, "Early shutdown")
+    @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
     def test_assert_strict_callback(self):
         " Assert within a registered task. "
@@ -57,7 +53,7 @@ class TestUnittest(DispersyTestFunc):
         yield 1.0
         self.fail("Should not reach this")
 
-    @failure_to_success(RuntimeError, "Early shutdown")
+    @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
     def test_KeyError_strict_callback(self):
         " KeyError within a registered task with strict enabled. "
@@ -78,7 +74,7 @@ class TestUnittest(DispersyTestFunc):
         yield 1.0
         self.assertTrue(True)
 
-    @failure_to_success(RuntimeError, "Early shutdown")
+    @failure_to_success(AssertionError, "This must fail")
     @call_on_dispersy_thread
     def test_assert_strict_callback_generator(self):
         " Assert within a registered generator task. "
@@ -103,7 +99,7 @@ class TestUnittest(DispersyTestFunc):
         yield 1.0
         self.assertTrue(True)
 
-    @failure_to_success(RuntimeError, "Early shutdown")
+    @failure_to_success(KeyError, "This must fail")
     @call_on_dispersy_thread
     def test_KeyError_strict_callback_generator(self):
         " KeyError within a registered generator task. "


### PR DESCRIPTION
Dispersy.stop calls Callback.stop, which now takes a final_func
parameter.  This is called (once) when Callback.stop has shutdown all
existing tasks.
