### PR TITLE
Cache split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 *.pyc
 *.pyo
-*~
-\#*\#
 *_flymake.py
+*~
+/.coverage
+/.noseids
+/.ropeproject/config.py
+/TAGS
+/coverage.xml
+/nosetests.xml
+/skip_nosetests.xml
+/tests/.noseids
+\#*\#

--- a/cache.py
+++ b/cache.py
@@ -67,7 +67,7 @@ class IntroductionRequestCache(NumberCache):
 
     def _check_if_both_received(self):
         if self._introduction_response_received and self._puncture_received:
-            self.community.dispersy.request_cache.pop(self.identifier)
+            self.community.request_cache.pop(self.identifier)
 
     def on_introduction_response(self):
         self._introduction_response_received = True

--- a/cache.py
+++ b/cache.py
@@ -1,46 +1,9 @@
-
-import logging
-import netifaces
-import os
-import sys
-
-try:
-    # python 2.7 only...
-    from collections import OrderedDict
-except ImportError:
-    from .python27_ordereddict import OrderedDict
-
-from collections import defaultdict
-from itertools import groupby, islice, count
-from pprint import pformat
-from socket import inet_aton, error as socket_error
-from struct import unpack_from
 from time import time
 
-from .authentication import NoAuthentication, MemberAuthentication, DoubleMemberAuthentication
-from .bloomfilter import BloomFilter
-from .bootstrap import Bootstrap
-from .candidate import BootstrapCandidate, LoopbackCandidate, WalkCandidate, Candidate
-from .crypto import DispersyCrypto, ECCrypto
-from .destination import CommunityDestination, CandidateDestination
-from .dispersydatabase import DispersyDatabase
-from .distribution import SyncDistribution, FullSyncDistribution, LastSyncDistribution, DirectDistribution, GlobalTimePruning
 from .logger import get_logger
 from .member import DummyMember, Member
-from .message import BatchConfiguration, Packet, Message
-from .message import DropMessage, DelayMessage, DelayMessageByProof, DelayMessageBySequence, DelayMessageByMissingMessage
-from .message import DropPacket, DelayPacket
-from .payload import AuthorizePayload, RevokePayload, UndoPayload
-from .payload import DestroyCommunityPayload
-from .payload import DynamicSettingsPayload
-from .payload import IdentityPayload, MissingIdentityPayload
-from .payload import IntroductionRequestPayload, IntroductionResponsePayload, PunctureRequestPayload, PuncturePayload
-from .payload import MissingMessagePayload, MissingLastMessagePayload
-from .payload import MissingSequencePayload, MissingProofPayload
-from .payload import SignatureRequestPayload, SignatureResponsePayload
+from .message import Message
 from .requestcache import Cache, NumberCache
-from .resolution import PublicResolution, LinearResolution
-from .statistics import DispersyStatistics
 
 logger = get_logger(__name__)
 

--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,219 @@
+
+import logging
+import netifaces
+import os
+import sys
+
+try:
+    # python 2.7 only...
+    from collections import OrderedDict
+except ImportError:
+    from .python27_ordereddict import OrderedDict
+
+from collections import defaultdict
+from itertools import groupby, islice, count
+from pprint import pformat
+from socket import inet_aton, error as socket_error
+from struct import unpack_from
+from time import time
+
+from .authentication import NoAuthentication, MemberAuthentication, DoubleMemberAuthentication
+from .bloomfilter import BloomFilter
+from .bootstrap import Bootstrap
+from .candidate import BootstrapCandidate, LoopbackCandidate, WalkCandidate, Candidate
+from .crypto import DispersyCrypto, ECCrypto
+from .destination import CommunityDestination, CandidateDestination
+from .dispersydatabase import DispersyDatabase
+from .distribution import SyncDistribution, FullSyncDistribution, LastSyncDistribution, DirectDistribution, GlobalTimePruning
+from .logger import get_logger
+from .member import DummyMember, Member
+from .message import BatchConfiguration, Packet, Message
+from .message import DropMessage, DelayMessage, DelayMessageByProof, DelayMessageBySequence, DelayMessageByMissingMessage
+from .message import DropPacket, DelayPacket
+from .payload import AuthorizePayload, RevokePayload, UndoPayload
+from .payload import DestroyCommunityPayload
+from .payload import DynamicSettingsPayload
+from .payload import IdentityPayload, MissingIdentityPayload
+from .payload import IntroductionRequestPayload, IntroductionResponsePayload, PunctureRequestPayload, PuncturePayload
+from .payload import MissingMessagePayload, MissingLastMessagePayload
+from .payload import MissingSequencePayload, MissingProofPayload
+from .payload import SignatureRequestPayload, SignatureResponsePayload
+from .requestcache import Cache, NumberCache
+from .resolution import PublicResolution, LinearResolution
+from .statistics import DispersyStatistics
+
+logger = get_logger(__name__)
+
+class SignatureRequestCache(NumberCache):
+
+    @staticmethod
+    def create_identifier(number):
+        assert isinstance(number, (int, long)), type(number)
+        return u"request-cache:signature-request:%d" % (number,)
+
+    def __init__(self, request_cache, members, response_func, response_args, timeout):
+        super(SignatureRequestCache, self).__init__(request_cache)
+        self.request = None
+        # MEMBERS is a list containing all the members that should add their signature.  currently
+        # we only support double signed messages, hence MEMBERS contains only a single Member
+        # instance.
+        self.members = members
+        self.response_func = response_func
+        self.response_args = response_args
+        self._timeout_delay = timeout
+
+    @property
+    def timeout_delay(self):
+        return self._timeout_delay
+
+    def on_timeout(self):
+        logger.debug("signature timeout")
+        self.response_func(self, None, True, *self.response_args)
+
+
+class IntroductionRequestCache(NumberCache):
+    @staticmethod
+    def create_identifier(number):
+        assert isinstance(number, (int, long)), type(number)
+        return u"request-cache:introduction-request:%d" % (number,)
+
+    @property
+    def timeout_delay(self):
+        # we will accept the response at most 10.5 seconds after our request
+        return 10.5
+
+    def __init__(self, community, helper_candidate):
+        super(IntroductionRequestCache, self).__init__(community.request_cache)
+        self.community = community
+        self.helper_candidate = helper_candidate
+        self.response_candidate = None
+        self.puncture_candidate = None
+        self._introduction_response_received = False
+        self._puncture_received = False
+
+    def on_timeout(self):
+        # helper_candidate did not respond to a request message in this community.  after some time
+        # inactive candidates become obsolete and will be removed by
+        # _periodically_cleanup_candidates
+        logger.debug("walker timeout for %s", self.helper_candidate)
+
+        self.community.dispersy.statistics.dict_inc(self.community.dispersy.statistics.walk_fail, self.helper_candidate.sock_addr)
+
+        # set the candidate to obsolete
+        self.helper_candidate.obsolete(time())
+
+    def _check_if_both_received(self):
+        if self._introduction_response_received and self._puncture_received:
+            self.community.dispersy.request_cache.pop(self.identifier)
+
+    def on_introduction_response(self):
+        self._introduction_response_received = True
+        self._check_if_both_received()
+
+    def on_puncture(self):
+        self._puncture_received = True
+        self._check_if_both_received()
+
+
+class MissingSomethingCache(Cache):
+
+    def __init__(self, timeout, *create_identifier_args):
+        super(MissingSomethingCache, self).__init__(self.create_identifier(*create_identifier_args))
+        logger.debug("%s: waiting for %.1f seconds", self.__class__.__name__, timeout)
+        self._timeout_delay = timeout
+        self.callbacks = []
+
+    @property
+    def timeout_delay(self):
+        return self._timeout_delay
+
+    def on_timeout(self):
+        logger.debug("%s: timeout on %d callbacks", self.__class__.__name__, len(self.callbacks))
+        for func, args in self.callbacks:
+            func(None, *args)
+
+
+class MissingMemberCache(MissingSomethingCache):
+
+    @staticmethod
+    def create_identifier(member):
+        assert isinstance(member, DummyMember), type(member)
+        return u"request-cache:missing-member:%s" % (member.mid.encode("HEX"),)
+
+
+class MissingMessageCache(MissingSomethingCache):
+
+    @staticmethod
+    def create_identifier(member, global_time):
+        assert isinstance(member, DummyMember), type(member)
+        assert isinstance(global_time, (int, long)), type(global_time)
+        return u"request-cache:missing-message:%s:%d" % (member.mid.encode("HEX"), global_time)
+
+    @classmethod
+    def create_identifier_from_message(cls, message):
+        assert isinstance(message, Message.Implementation), type(message)
+        return cls.create_identifier(message.authentication.member, message.distribution.global_time)
+
+
+class MissingLastMessageCache(MissingSomethingCache):
+
+    @staticmethod
+    def create_identifier(member, message):
+        assert isinstance(member, DummyMember), type(member)
+        assert isinstance(message, (Message, Message.Implementation)), type(message)
+        return u"request-cache:missing-last-message:%s:%s" % (member.mid.encode("HEX"), message.name.encode("UTF-8"))
+
+
+class MissingProofCache(MissingSomethingCache):
+
+    @staticmethod
+    def create_identifier():
+        return u"request-cache:missing-proof"
+
+    @classmethod
+    def create_identifier_from_message(cls, message):
+        assert isinstance(message, Message.Implementation), type(message)
+        return cls.create_identifier()
+
+    def __init__(self, timeout):
+        super(MissingProofCache, self).__init__(timeout)
+
+        # duplicates contains the (meta messages, member) for which we have already requesting
+        # proof, this allows us send fewer duplicate requests
+        self.duplicates = []
+
+
+class MissingSequenceOverviewCache(Cache):
+
+    @staticmethod
+    def create_identifier(member, message):
+        assert isinstance(member, Member), type(member)
+        assert isinstance(message, (Message, Message.Implementation)), type(message)
+        return u"request-cache:missing-sequence-overview:%s:%s" % (member.mid.encode("HEX"), message.name.encode("UTF-8"))
+
+    def __init__(self, timeout, *create_identifier_args):
+        super(MissingSequenceOverviewCache, self).__init__(self.create_identifier(*create_identifier_args))
+        self._timeout_delay = timeout
+        self.missing_high = 0
+
+    @property
+    def timeout_delay(self):
+        return self._timeout_delay
+
+    def on_timeout(self):
+        pass
+
+
+class MissingSequenceCache(MissingSomethingCache):
+
+    @staticmethod
+    def create_identifier(member, message, missing_global_time_high):
+        assert isinstance(member, Member), type(member)
+        assert isinstance(message, (Message, Message.Implementation)), type(message)
+        assert isinstance(missing_global_time_high, (int, long)), type(missing_global_time_high)
+        return u"request-cache:missing-sequence:%s:%s:%d" % (member.mid.encode("HEX"), message.name.encode("UTF-8"), missing_global_time_high)
+
+    @classmethod
+    def create_identifier_from_message(cls, message):
+        assert isinstance(message, Message.Implementation), type(message)
+        return cls.create_identifier(message.authentication.member, message, message.distribution.sequence_number)

--- a/community.py
+++ b/community.py
@@ -1549,7 +1549,7 @@ class Community(object):
     def handle_missing_messages(self, messages, *classes):
         if __debug__:
             from .message import Message
-            from .dispersy import MissingSomethingCache
+            from .cache import MissingSomethingCache
             assert all(isinstance(message, Message.Implementation) for message in messages), [type(message) for message in messages]
             assert all(issubclass(cls, MissingSomethingCache) for cls in classes), [type(cls) for cls in classes]
 

--- a/dispersy.py
+++ b/dispersy.py
@@ -36,30 +36,23 @@ A community can tweak the policies and how they behave by changing the parameter
 supply.  Aside from the four policies, each meta-message also defines the community that it is part
 of, the name it uses as an internal identifier, and the class that will contain the payload.
 """
-
 import logging
-import netifaces
 import os
 import sys
-
-try:
-    # python 2.7 only...
-    from collections import OrderedDict
-except ImportError:
-    from .python27_ordereddict import OrderedDict
-
 from collections import defaultdict
-from itertools import groupby, islice, count
+from itertools import groupby, count
 from pprint import pformat
 from socket import inet_aton, error as socket_error
 from struct import unpack_from
 from time import time
 
+import netifaces
 
-from .cache import *
 from .authentication import NoAuthentication, MemberAuthentication, DoubleMemberAuthentication
 from .bloomfilter import BloomFilter
 from .bootstrap import Bootstrap
+from .cache import (MissingMemberCache, MissingProofCache, IntroductionRequestCache, MissingSequenceCache,
+                    MissingSequenceOverviewCache, SignatureRequestCache, MissingMessageCache)
 from .candidate import BootstrapCandidate, LoopbackCandidate, WalkCandidate, Candidate
 from .crypto import DispersyCrypto, ECCrypto
 from .destination import CommunityDestination, CandidateDestination
@@ -67,20 +60,24 @@ from .dispersydatabase import DispersyDatabase
 from .distribution import SyncDistribution, FullSyncDistribution, LastSyncDistribution, DirectDistribution, GlobalTimePruning
 from .logger import get_logger
 from .member import DummyMember, Member
-from .message import BatchConfiguration, Packet, Message
-from .message import DropMessage, DelayMessage, DelayMessageByProof, DelayMessageBySequence, DelayMessageByMissingMessage
-from .message import DropPacket, DelayPacket
-from .payload import AuthorizePayload, RevokePayload, UndoPayload
-from .payload import DestroyCommunityPayload
-from .payload import DynamicSettingsPayload
-from .payload import IdentityPayload, MissingIdentityPayload
-from .payload import IntroductionRequestPayload, IntroductionResponsePayload, PunctureRequestPayload, PuncturePayload
-from .payload import MissingMessagePayload, MissingLastMessagePayload
-from .payload import MissingSequencePayload, MissingProofPayload
-from .payload import SignatureRequestPayload, SignatureResponsePayload
-from .requestcache import Cache, NumberCache
+from .message import (BatchConfiguration, Packet, Message, DropMessage, DelayMessage, DelayMessageByProof,
+                      DelayMessageBySequence, DelayMessageByMissingMessage, DropPacket, DelayPacket)
+from .payload import (AuthorizePayload, RevokePayload, UndoPayload, DestroyCommunityPayload, DynamicSettingsPayload,
+                      IdentityPayload, MissingIdentityPayload, IntroductionRequestPayload, IntroductionResponsePayload,
+                      PunctureRequestPayload, PuncturePayload, MissingMessagePayload, MissingLastMessagePayload,
+                      MissingSequencePayload, MissingProofPayload, SignatureRequestPayload, SignatureResponsePayload)
 from .resolution import PublicResolution, LinearResolution
 from .statistics import DispersyStatistics
+
+
+try:
+    # python 2.7 only...
+    from collections import OrderedDict
+except ImportError:
+    from .python27_ordereddict import OrderedDict
+
+
+
 
 logger = get_logger(__name__)
 

--- a/dispersy.py
+++ b/dispersy.py
@@ -55,6 +55,8 @@ from socket import inet_aton, error as socket_error
 from struct import unpack_from
 from time import time
 
+
+from .cache import *
 from .authentication import NoAuthentication, MemberAuthentication, DoubleMemberAuthentication
 from .bloomfilter import BloomFilter
 from .bootstrap import Bootstrap
@@ -79,186 +81,12 @@ from .payload import SignatureRequestPayload, SignatureResponsePayload
 from .requestcache import Cache, NumberCache
 from .resolution import PublicResolution, LinearResolution
 from .statistics import DispersyStatistics
+
 logger = get_logger(__name__)
 
 if __debug__:
     from .callback import Callback
     from .endpoint import Endpoint
-
-
-class SignatureRequestCache(NumberCache):
-
-    @staticmethod
-    def create_identifier(number):
-        assert isinstance(number, (int, long)), type(number)
-        return u"request-cache:signature-request:%d" % (number,)
-
-    def __init__(self, request_cache, members, response_func, response_args, timeout):
-        super(SignatureRequestCache, self).__init__(request_cache)
-        self.request = None
-        # MEMBERS is a list containing all the members that should add their signature.  currently
-        # we only support double signed messages, hence MEMBERS contains only a single Member
-        # instance.
-        self.members = members
-        self.response_func = response_func
-        self.response_args = response_args
-        self._timeout_delay = timeout
-
-    @property
-    def timeout_delay(self):
-        return self._timeout_delay
-
-    def on_timeout(self):
-        logger.debug("signature timeout")
-        self.response_func(self, None, True, *self.response_args)
-
-
-class IntroductionRequestCache(NumberCache):
-    @staticmethod
-    def create_identifier(number):
-        assert isinstance(number, (int, long)), type(number)
-        return u"request-cache:introduction-request:%d" % (number,)
-
-    @property
-    def timeout_delay(self):
-        # we will accept the response at most 10.5 seconds after our request
-        return 10.5
-
-    def __init__(self, community, helper_candidate):
-        super(IntroductionRequestCache, self).__init__(community.request_cache)
-        self.community = community
-        self.helper_candidate = helper_candidate
-        self.response_candidate = None
-        self.puncture_candidate = None
-        self._introduction_response_received = False
-        self._puncture_received = False
-
-    def on_timeout(self):
-        # helper_candidate did not respond to a request message in this community.  after some time
-        # inactive candidates become obsolete and will be removed by
-        # _periodically_cleanup_candidates
-        logger.debug("walker timeout for %s", self.helper_candidate)
-
-        self.community.dispersy.statistics.dict_inc(self.community.dispersy.statistics.walk_fail, self.helper_candidate.sock_addr)
-
-        # set the candidate to obsolete
-        self.helper_candidate.obsolete(time())
-
-    def _check_if_both_received(self):
-        if self._introduction_response_received and self._puncture_received:
-            self.community.request_cache.pop(self.identifier)
-
-    def on_introduction_response(self):
-        self._introduction_response_received = True
-        self._check_if_both_received()
-
-    def on_puncture(self):
-        self._puncture_received = True
-        self._check_if_both_received()
-
-
-class MissingSomethingCache(Cache):
-
-    def __init__(self, timeout, *create_identifier_args):
-        super(MissingSomethingCache, self).__init__(self.create_identifier(*create_identifier_args))
-        logger.debug("%s: waiting for %.1f seconds", self.__class__.__name__, timeout)
-        self._timeout_delay = timeout
-        self.callbacks = []
-
-    @property
-    def timeout_delay(self):
-        return self._timeout_delay
-
-    def on_timeout(self):
-        logger.debug("%s: timeout on %d callbacks", self.__class__.__name__, len(self.callbacks))
-        for func, args in self.callbacks:
-            func(None, *args)
-
-
-class MissingMemberCache(MissingSomethingCache):
-
-    @staticmethod
-    def create_identifier(member):
-        assert isinstance(member, DummyMember), type(member)
-        return u"request-cache:missing-member:%s" % (member.mid.encode("HEX"),)
-
-
-class MissingMessageCache(MissingSomethingCache):
-
-    @staticmethod
-    def create_identifier(member, global_time):
-        assert isinstance(member, DummyMember), type(member)
-        assert isinstance(global_time, (int, long)), type(global_time)
-        return u"request-cache:missing-message:%s:%d" % (member.mid.encode("HEX"), global_time)
-
-    @classmethod
-    def create_identifier_from_message(cls, message):
-        assert isinstance(message, Message.Implementation), type(message)
-        return cls.create_identifier(message.authentication.member, message.distribution.global_time)
-
-
-class MissingLastMessageCache(MissingSomethingCache):
-
-    @staticmethod
-    def create_identifier(member, message):
-        assert isinstance(member, DummyMember), type(member)
-        assert isinstance(message, (Message, Message.Implementation)), type(message)
-        return u"request-cache:missing-last-message:%s:%s" % (member.mid.encode("HEX"), message.name.encode("UTF-8"))
-
-
-class MissingProofCache(MissingSomethingCache):
-
-    @staticmethod
-    def create_identifier():
-        return u"request-cache:missing-proof"
-
-    @classmethod
-    def create_identifier_from_message(cls, message):
-        assert isinstance(message, Message.Implementation), type(message)
-        return cls.create_identifier()
-
-    def __init__(self, timeout):
-        super(MissingProofCache, self).__init__(timeout)
-
-        # duplicates contains the (meta messages, member) for which we have already requesting
-        # proof, this allows us send fewer duplicate requests
-        self.duplicates = []
-
-
-class MissingSequenceOverviewCache(Cache):
-
-    @staticmethod
-    def create_identifier(member, message):
-        assert isinstance(member, Member), type(member)
-        assert isinstance(message, (Message, Message.Implementation)), type(message)
-        return u"request-cache:missing-sequence-overview:%s:%s" % (member.mid.encode("HEX"), message.name.encode("UTF-8"))
-
-    def __init__(self, timeout, *create_identifier_args):
-        super(MissingSequenceOverviewCache, self).__init__(self.create_identifier(*create_identifier_args))
-        self._timeout_delay = timeout
-        self.missing_high = 0
-
-    @property
-    def timeout_delay(self):
-        return self._timeout_delay
-
-    def on_timeout(self):
-        pass
-
-
-class MissingSequenceCache(MissingSomethingCache):
-
-    @staticmethod
-    def create_identifier(member, message, missing_global_time_high):
-        assert isinstance(member, Member), type(member)
-        assert isinstance(message, (Message, Message.Implementation)), type(message)
-        assert isinstance(missing_global_time_high, (int, long)), type(missing_global_time_high)
-        return u"request-cache:missing-sequence:%s:%s:%d" % (member.mid.encode("HEX"), message.name.encode("UTF-8"), missing_global_time_high)
-
-    @classmethod
-    def create_identifier_from_message(cls, message):
-        assert isinstance(message, Message.Implementation), type(message)
-        return cls.create_identifier(message.authentication.member, message, message.distribution.sequence_number)
 
 
 class Dispersy(object):
@@ -2560,17 +2388,17 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
     def _get_packets_for_bloomfilters(self, community, requests, include_inactive=True):
         """
         Return all packets matching a Bloomfilter request
-        
+
         @param community: The community wherein all requests were received
         @type messages: [Community]
 
         @param requests: A list of requests, each of them being a tuple consisting of the request,
-         time_low, time_high, offset, and modulo  
-        @type requests: list 
+         time_low, time_high, offset, and modulo
+        @type requests: list
 
-        @param include_inactive: When False only active packets (due to pruning) are returned 
+        @param include_inactive: When False only active packets (due to pruning) are returned
         @type include_inactive: bool
-        
+
         @return: An generator yielding the original request and a generator consisting of the packets matching the request
         """
 

--- a/dispersy.py
+++ b/dispersy.py
@@ -2364,8 +2364,8 @@ ORDER BY global_time""", (meta.database_id, member_database_id)))
                 messages_with_sync.append((message, time_low, time_high, offset, modulo))
 
         if messages_with_sync:
-            payload = message.payload
             for message, generator in self._get_packets_for_bloomfilters(community, messages_with_sync, include_inactive=False):
+                payload = message.payload
                 # we limit the response by byte_limit bytes
                 byte_limit = community.dispersy_sync_response_limit
 

--- a/tests/debugcommunity/community.py
+++ b/tests/debugcommunity/community.py
@@ -3,7 +3,7 @@ from ...candidate import Candidate
 from ...community import Community, HardKilledCommunity
 from ...conversion import DefaultConversion
 from ...destination import CommunityDestination
-from ...dispersy import MissingSequenceCache
+from ...cache import MissingSequenceCache
 from ...distribution import DirectDistribution, FullSyncDistribution, LastSyncDistribution, GlobalTimePruning
 from ...logger import get_logger
 from ...message import Message, DelayMessageByProof


### PR DESCRIPTION
Split the *Cache classes from dispersy.py to cache.py, update all imports on dispersy, it breaks Tribler, a pull request for it will be coming shortly
