### PR TITLE
Add the sequence number in the sync table and use that instead of

### DIFF
--- a/distribution.py
+++ b/distribution.py
@@ -288,8 +288,11 @@ class FullSyncDistribution(SyncDistribution):
         super(FullSyncDistribution, self).setup(message)
         if self._enable_sequence_number:
             # obtain the most recent sequence number that we have used
-            self._current_sequence_number, = message.community.dispersy.database.execute(u"SELECT COUNT(1) FROM sync WHERE member = ? AND meta_message = ?",
-                                                                                         (message.community.my_member.database_id, message.database_id)).next()
+            current_sequence_number, = message.community.dispersy.database.execute(
+                u"SELECT MAX(sequence) FROM sync WHERE member = ? AND meta_message = ?",
+                (message.community.my_member.database_id, message.database_id)).next()
+
+            self._current_sequence_number = current_sequence_number or 0
 
     def claim_sequence_number(self):
         assert self._enable_sequence_number

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -128,7 +128,7 @@ class TestIncomingMissingSequence(DispersyTestFunc):
         self.requests(1, [1, 2, 3, 4, 5], (1, 2), (2, 3), (3, 4), (4, 5))
 
     def test_requests_1_11(self):
-        self.requests(1, [1, 2, 3, 4, 5, 6, 7, 8], (1, 2), (4, 5), (7, 8))
+        self.requests(1, [1, 2, 4, 5, 7, 8], (1, 2), (4, 5), (7, 8))
 
     def test_requests_2_7(self):
         self.requests(2, [1], (1, 1), (1, 1), (1, 1))
@@ -137,7 +137,7 @@ class TestIncomingMissingSequence(DispersyTestFunc):
         self.requests(2, [1, 2, 3, 4, 5], (1, 2), (2, 3), (3, 4), (4, 5))
 
     def test_requests_2_11(self):
-        self.requests(2, [1, 2, 3, 4, 5, 6, 7, 8], (1, 2), (4, 5), (7, 8))
+        self.requests(2, [1, 2, 4, 5, 7, 8], (1, 2), (4, 5), (7, 8))
 
     # multi-range requests, in different orders
     def test_requests_1_13(self):
@@ -147,10 +147,10 @@ class TestIncomingMissingSequence(DispersyTestFunc):
         self.requests(1, [1, 2, 3, 4, 5], (4, 5), (3, 4), (1, 2), (2, 3))
 
     def test_requests_1_16(self):
-        self.requests(1, [1, 2, 3, 4, 5], (5, 5), (1, 1))
+        self.requests(1, [1, 5], (5, 5), (1, 1))
 
     def test_requests_1_17(self):
-        self.requests(1, [1, 2, 3, 4, 5, 6, 7, 8], (1, 2), (7, 8), (4, 5))
+        self.requests(1, [1, 2, 4, 5, 7, 8], (1, 2), (7, 8), (4, 5))
 
     def test_requests_2_13(self):
         self.requests(2, [1], (1, 1), (1, 1), (1, 1))
@@ -159,10 +159,10 @@ class TestIncomingMissingSequence(DispersyTestFunc):
         self.requests(2, [1, 2, 3, 4, 5], (4, 5), (3, 4), (1, 2), (2, 3))
 
     def test_requests_2_16(self):
-        self.requests(2, [1, 2, 3, 4, 5], (5, 5), (1, 1))
+        self.requests(2, [1, 5], (5, 5), (1, 1))
 
     def test_requests_2_17(self):
-        self.requests(2, [1, 2, 3, 4, 5, 6, 7, 8], (1, 2), (7, 8), (4, 5))
+        self.requests(2, [1, 2, 4, 5, 7, 8], (1, 2), (7, 8), (4, 5))
 
     # single range requests, invalid requests
     def test_requests_1_19(self):


### PR DESCRIPTION
inferring the sequence number depending on the amount of messages in the
table.
Fix the multiple range behavior to only send back the messages
actually contained between the set of ranges.
Fix the tests to check for the correct behavior.
