### PR TITLE
Fix for sequence number check, messages aren't inserted in order.

### DIFF
--- a/dispersy.py
+++ b/dispersy.py
@@ -1687,7 +1687,7 @@ WHERE sync.meta_message = ? AND double_signed_sync.member1 = ? AND double_signed
         logger.debug("attempting to store %d %s messages", len(messages), meta.name)
         is_double_member_authentication = isinstance(meta.authentication, DoubleMemberAuthentication)
         highest_global_time = 0
-        highest_sequence_number = defaultdict(0)
+        highest_sequence_number = defaultdict(int)
 
         # update_sync_range = set()
         for message in messages:

--- a/dispersy.py
+++ b/dispersy.py
@@ -1687,7 +1687,7 @@ WHERE sync.meta_message = ? AND double_signed_sync.member1 = ? AND double_signed
         logger.debug("attempting to store %d %s messages", len(messages), meta.name)
         is_double_member_authentication = isinstance(meta.authentication, DoubleMemberAuthentication)
         highest_global_time = 0
-        highest_sequence_number = 0
+        highest_sequence_number = defaultdict(0)
 
         # update_sync_range = set()
         for message in messages:
@@ -1730,18 +1730,17 @@ WHERE sync.meta_message = ? AND double_signed_sync.member1 = ? AND double_signed
             # update global time
             highest_global_time = max(highest_global_time, message.distribution.global_time)
             if isinstance(meta.distribution, FullSyncDistribution) and message.distribution.enable_sequence_number:
-                highest_sequence_number = max(highest_sequence_number, message.distribution.sequence_number)
+                highest_sequence_number[message.authentication.member.database_id] = max(highest_sequence_number[message.authentication.member.database_id], message.distribution.sequence_number)
 
 
         if __debug__ and highest_sequence_number:
             # when sequence numbers are enabled, we must have exactly
             # message.distribution.sequence_number messages in the database
-            count_, = self._database.execute(u"SELECT COUNT(*) FROM sync "
-                                            u"WHERE meta_message = ? AND member = ? AND sequence BETWEEN 1 AND ?",
-                                            (message.database_id,
-                                            highest_sequence_number,
-                                            )).next()
-            assert count_ == highest_sequence_number, [count_, highest_sequence_number]
+            for member_id, max_sequence_number in highest_sequence_number.iteritems():
+                count_, = self._database.execute(u"SELECT COUNT(*) FROM sync "
+                                                u"WHERE meta_message = ? AND member = ? AND sequence BETWEEN 1 AND ?",
+                                                (message.database_id, member_id, max_sequence_number)).next()
+                assert count_ == max_sequence_number, [count_, max_sequence_number]
 
         if isinstance(meta.distribution, LastSyncDistribution):
             # delete packets that have become obsolete

--- a/dispersy.py
+++ b/dispersy.py
@@ -1729,7 +1729,7 @@ WHERE sync.meta_message = ? AND double_signed_sync.member1 = ? AND double_signed
 
             # update global time
             highest_global_time = max(highest_global_time, message.distribution.global_time)
-            if message.distribution.enable_sequence_number:
+            if isinstance(meta.distribution, FullSyncDistribution) and message.distribution.enable_sequence_number:
                 highest_sequence_number = max(highest_sequence_number, message.distribution.sequence_number)
 
 


### PR DESCRIPTION
Hence, we can only check after inserting all messages.
