### PR TITLE
Optimize sqlite db

### DIFF
--- a/database.py
+++ b/database.py
@@ -151,6 +151,7 @@ class Database(object):
         #
         if not (journal_mode == u"WAL" or self._file_path == u":memory:"):
             logger.debug("PRAGMA journal_mode = WAL (previously: %s) [%s]", journal_mode, self._file_path)
+            self._cursor.execute(u"PRAGMA locking_mode = EXCLUSIVE")
             self._cursor.execute(u"PRAGMA journal_mode = WAL")
 
         else:


### PR DESCRIPTION
Disabled the "shm" sqlite db file which is a shared-memory file for multi-threading applications.
