### PR TITLE
Curve25519 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libnacl"]
+	path = libnacl
+	url = https://github.com/saltstack/libnacl

--- a/crypto.py
+++ b/crypto.py
@@ -1,26 +1,34 @@
 from hashlib import sha1
 from math import ceil
 from struct import Struct
+from json import dumps, loads
+import logging
 
 from M2Crypto import EC, BIO
 from M2Crypto.EC import EC_pub
 
-from .util import attach_runtime_statistics
+import libnacl.dual
 
+from .util import attach_runtime_statistics
+from libnacl.encode import hex_decode
 
 _STRUCT_L = Struct(">L")
 
 # Allow all available curves.
 # Niels: 16-12-2013, if it starts with NID_
-_CURVES = dict((unicode(curve), getattr(EC, curve)) for curve in dir(EC) if curve.startswith("NID_"))
+_CURVES = dict((unicode(curve), (getattr(EC, curve), "M2Crypto")) for curve in dir(EC) if curve.startswith("NID_"))
 
 # We want to provide a few default curves.  We will change these curves as new become available and
 # old ones to small to provide sufficient security.
-_CURVES.update({u"very-low": EC.NID_sect163k1,
-                u"low": EC.NID_sect233k1,
-                u"medium": EC.NID_sect409k1,
-                u"high": EC.NID_sect571r1})
+_CURVES.update({u"very-low": (EC.NID_sect163k1, "M2Crypto"),
+                u"low": (EC.NID_sect233k1, "M2Crypto"),
+                u"medium": (EC.NID_sect409k1, "M2Crypto"),
+                u"high": (EC.NID_sect571r1, "M2Crypto")})
 
+# Add custom curves, not provided by M2Crypto
+_CURVES.update({u'curve25519': (None, "libnacl")})
+
+logger = logging.getLogger(__name__)
 
 class DispersyCrypto(object):
 
@@ -82,10 +90,14 @@ class DispersyCrypto(object):
 class ECCrypto(DispersyCrypto):
     """
     A crypto object which provides a layer between Dispersy and low level eccrypographic features.
-
-    @author: Boudewijn Schoon
-    @organization: Technical University Delft
-    @contact: dispersy@frayja.com
+    
+    Most methods are implemented by:
+        @author: Boudewijn Schoon
+        @organization: Technical University Delft
+        @contact: dispersy@frayja.com
+        
+    However since then, most functionality was completely rewritten by:
+        @author: Niels Zeilemaker
     """
 
     def _progress(self, *args):
@@ -121,75 +133,31 @@ class ECCrypto(DispersyCrypto):
         assert isinstance(security_level, unicode)
         assert security_level in _CURVES
 
-        ec = EC.gen_params(_CURVES[security_level])
-        ec.gen_key()
-        return ec
+        curve = _CURVES[security_level]
+        if curve[1] == "M2Crypto":
+            return M2CryptoSK(curve[0])
 
-    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
-    def pem_to_bin(self, pem):
-        """
-        Convert a key in the PEM format into a key in the binary format.
-        @note: Enrcypted pem's are NOT supported and will silently fail.
-        """
-        return "".join(pem.split("\n")[1:-2]).decode("BASE64")
-
-    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
-    def key_to_pem(self, ec):
-        "Convert a key to the PEM format."
-        bio = BIO.MemoryBuffer()
-        if isinstance(ec, EC_pub):
-            ec.save_pub_key_bio(bio)
-        else:
-            ec.save_key_bio(bio, None, lambda *args: "")
-        return bio.read_all()
-
-    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
-    def key_from_private_pem(self, pem, password=None):
-        "Get the EC from a public/private keypair stored in the PEM."
-        def get_password(*args):
-            return password or ""
-        return EC.load_key_bio(BIO.MemoryBuffer(pem), get_password)
-
-    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
-    def key_from_public_pem(self, pem):
-        "Get the EC from a public PEM."
-        return EC.load_pub_key_bio(BIO.MemoryBuffer(pem))
-
-    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
-    def is_valid_private_pem(self, pem):
-        "Returns True if the input is a valid public/private keypair"
-        try:
-            self.key_from_private_pem(pem)
-        except:
-            return False
-        return True
-
-    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
-    def is_valid_public_pem(self, pem):
-        "Returns True if the input is a valid public key"
-        try:
-            self.key_from_public_pem(pem)
-        except:
-            return False
-        return True
+        if curve[1] == "libnacl":
+            return LibNaCLSK()
 
     @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
     def key_to_bin(self, ec):
         "Convert the key to a binary format."
-        assert isinstance(ec, (EC.EC, EC_pub)), ec
-        return self.pem_to_bin(self.key_to_pem(ec))
+        assert isinstance(ec, (M2CryptoSK, M2CryptoPK, LibNaCLSK, LibNaCLPK)), ec
+        return ec.key_to_bin()
 
     @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
     def key_to_hash(self, ec):
         "Get a hash representation from a key."
-        return sha1(self.key_to_bin(ec.pub())).digest()
+        assert isinstance(ec, (EC.EC, EC_pub, LibNaCLSK, LibNaCLPK)), ec
+        return sha1(ec.key_to_bin(ec.pub())).digest()
 
     @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
     def is_valid_private_bin(self, string):
         "Returns True if the input is a valid public/private keypair stored in a binary format"
         try:
             self.key_from_private_bin(string)
-        except:
+        except Exception as e:
             return False
         return True
 
@@ -205,22 +173,22 @@ class ECCrypto(DispersyCrypto):
     @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
     def key_from_private_bin(self, string):
         "Get the EC from a public/private keypair stored in a binary format."
-        return self.key_from_private_pem("".join(("-----BEGIN EC PRIVATE KEY-----\n",
-                                            string.encode("BASE64"),
-                                            "-----END EC PRIVATE KEY-----\n")))
+        if string.startswith("LibNaCLSK:"):
+            return LibNaCLSK(string[10:])
+        return M2CryptoSK(keystring=string)
 
     @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
     def key_from_public_bin(self, string):
         "Get the EC from a public key in binary format."
-        return self.key_from_public_pem("".join(("-----BEGIN PUBLIC KEY-----\n",
-                                           string.encode("BASE64"),
-                                           "-----END PUBLIC KEY-----\n")))
+        if string.startswith("LibNaCLPK:"):
+            return LibNaCLPK(string[10:])
+        return M2CryptoPK(keystring=string)
 
     def get_signature_length(self, ec):
         """
         Returns the length, in bytes, of each signature made using EC.
         """
-        return int(ceil(len(ec) / 8.0)) * 2
+        return ec.get_signature_length()
 
     @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
     def create_signature(self, ec, data):
@@ -228,16 +196,7 @@ class ECCrypto(DispersyCrypto):
         Returns the signature of DIGEST made using EC.
         """
         assert isinstance(data, str), type(data)
-        length = int(ceil(len(ec) / 8.0))
-        digest = sha1(data).digest()
-
-        mpi_r, mpi_s = ec.sign_dsa(digest)
-        length_r, = _STRUCT_L.unpack_from(mpi_r)
-        r = mpi_r[-min(length, length_r):]
-        length_s, = _STRUCT_L.unpack_from(mpi_s)
-        s = mpi_s[-min(length, length_s):]
-
-        return "".join(("\x00" * (length - len(r)), r, "\x00" * (length - len(s)), s))
+        return ec.signature(data)
 
     @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
     def is_valid_signature(self, ec, data, signature):
@@ -247,41 +206,11 @@ class ECCrypto(DispersyCrypto):
         assert isinstance(data, str), type(data)
         assert isinstance(signature, str), type(signature)
         assert len(signature) == self.get_signature_length(ec), [len(signature), self.get_signature_length(ec)]
-        length = len(signature) / 2
+
         try:
-            r = signature[:length]
-            # remove all "\x00" prefixes
-            while r and r[0] == "\x00":
-                r = r[1:]
-            # prepend "\x00" when the most significant bit is set
-            if ord(r[0]) & 128:
-                r = "\x00" + r
-
-            s = signature[length:]
-            # remove all "\x00" prefixes
-            while s and s[0] == "\x00":
-                s = s[1:]
-            # prepend "\x00" when the most significant bit is set
-            if ord(s[0]) & 128:
-                s = "\x00" + s
-
-            mpi_r = _STRUCT_L.pack(len(r)) + r
-            mpi_s = _STRUCT_L.pack(len(s)) + s
-
-            # mpi_r3 = bn_to_mpi(bin_to_bn(signature[:length]))
-            # mpi_s3 = bn_to_mpi(bin_to_bn(signature[length:]))
-
-            # if not mpi_r == mpi_r3:
-            #     raise RuntimeError([mpi_r.encode("HEX"), mpi_r3.encode("HEX")])
-            # if not mpi_s == mpi_s3:
-            #     raise RuntimeError([mpi_s.encode("HEX"), mpi_s3.encode("HEX")])
-
-            digest = sha1(data).digest()
-            return bool(ec.verify_dsa(digest, mpi_r, mpi_s))
-
+            return ec.verify(signature, data)
         except:
             return False
-
 
 class NoVerifyCrypto(ECCrypto):
     """
@@ -300,3 +229,149 @@ class NoCrypto(NoVerifyCrypto):
 
     def create_signature(self, ec, digest):
         return "0" * self.get_signature_length(ec)
+
+
+class M2CryptoPK():
+
+    def __init__(self, ec_pub=None, keystring=None):
+        if ec_pub:
+            self.ec = ec_pub
+        elif keystring:
+            self.ec = self.key_from_pem("-----BEGIN PUBLIC KEY-----\n%s-----END PUBLIC KEY-----\n" % keystring.encode("BASE64"))
+
+    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
+    def pem_to_bin(self, pem):
+        """
+        Convert a key in the PEM format into a key in the binary format.
+        @note: Enrcypted pem's are NOT supported and will silently fail.
+        """
+        return "".join(pem.split("\n")[1:-2]).decode("BASE64")
+
+    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
+    def key_to_pem(self):
+        "Convert a key to the PEM format."
+        bio = BIO.MemoryBuffer()
+        self.ec.save_pub_key_bio(bio)
+        return bio.read_all()
+
+    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
+    def key_from_pem(self, pem):
+        "Get the EC from a public PEM."
+        return EC.load_pub_key_bio(BIO.MemoryBuffer(pem))
+
+    def key_to_bin(self):
+        return self.pem_to_bin(self.key_to_pem())
+
+    def get_signature_length(self):
+        return int(ceil(len(self.ec) / 8.0)) * 2
+
+    def verify(self, signature, data):
+        length = len(signature) / 2
+        r = signature[:length]
+        # remove all "\x00" prefixes
+        while r and r[0] == "\x00":
+            r = r[1:]
+        # prepend "\x00" when the most significant bit is set
+        if ord(r[0]) & 128:
+            r = "\x00" + r
+
+        s = signature[length:]
+        # remove all "\x00" prefixes
+        while s and s[0] == "\x00":
+            s = s[1:]
+        # prepend "\x00" when the most significant bit is set
+        if ord(s[0]) & 128:
+            s = "\x00" + s
+
+        mpi_r = _STRUCT_L.pack(len(r)) + r
+        mpi_s = _STRUCT_L.pack(len(s)) + s
+
+        # mpi_r3 = bn_to_mpi(bin_to_bn(signature[:length]))
+        # mpi_s3 = bn_to_mpi(bin_to_bn(signature[length:]))
+
+        # if not mpi_r == mpi_r3:
+        #     raise RuntimeError([mpi_r.encode("HEX"), mpi_r3.encode("HEX")])
+        # if not mpi_s == mpi_s3:
+        #     raise RuntimeError([mpi_s.encode("HEX"), mpi_s3.encode("HEX")])
+
+        digest = sha1(data).digest()
+        return bool(self.ec.verify_dsa(digest, mpi_r, mpi_s))
+
+
+class M2CryptoSK(M2CryptoPK):
+
+    def __init__(self, curve=None, keystring=None):
+        if curve:
+            self.ec = EC.gen_params(curve)
+            self.ec.gen_key()
+
+        elif keystring:
+            self.ec = self.key_from_pem("-----BEGIN EC PRIVATE KEY-----\n%s-----END EC PRIVATE KEY-----\n" % keystring.encode("BASE64"))
+
+    def pub(self):
+        return M2CryptoPK(ec_pub=self.ec.pub())
+
+    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
+    def key_to_pem(self):
+        "Convert a key to the PEM format."
+        bio = BIO.MemoryBuffer()
+        self.ec.save_key_bio(bio, None, lambda *args: "")
+        return bio.read_all()
+
+    @attach_runtime_statistics(u"{0.__class__.__name__}.{function_name}")
+    def key_from_pem(self, pem):
+        "Get the EC from a public/private keypair stored in the PEM."
+        def get_password(*args):
+            return ""
+        return EC.load_key_bio(BIO.MemoryBuffer(pem), get_password)
+
+    def signature(self, msg):
+        length = int(ceil(len(self.ec) / 8.0))
+        digest = sha1(msg).digest()
+
+        mpi_r, mpi_s = self.ec.sign_dsa(digest)
+        length_r, = _STRUCT_L.unpack_from(mpi_r)
+        r = mpi_r[-min(length, length_r):]
+        length_s, = _STRUCT_L.unpack_from(mpi_s)
+        s = mpi_s[-min(length, length_s):]
+
+        return "".join(("\x00" * (length - len(r)), r, "\x00" * (length - len(s)), s))
+
+
+class LibNaCLPK(object):
+
+    def __init__(self, json={}, hex_pk=None, hex_vk=None):
+        if json:
+            json = loads(json)
+
+        self.crypt = libnacl.public.PublicKey(hex_decode(json.get('pk', hex_pk)))
+        self.veri = libnacl.sign.Verifier(json.get('vk', hex_vk))
+
+    def verify(self, signature, msg):
+        return self.veri.verify(signature + msg)
+
+    def key_to_bin(self):
+        return "LibNaCLPK:" + dumps({'pk': self.crypt.hex_pk(), 'vk': self.veri.hex_vk()})
+
+    def get_signature_length(self):
+        return libnacl.crypto_sign_BYTES
+
+
+class LibNaCLSK(LibNaCLPK):
+
+    def __init__(self, json={}):
+        if json:
+            json = loads(json)
+            self.key = libnacl.dual.DualSecret(hex_decode(json['crypt']), hex_decode(json['seed']))
+        else:
+            self.key = libnacl.dual.DualSecret()
+        self.veri = libnacl.sign.Verifier(self.key.hex_vk())
+
+    def pub(self):
+        return LibNaCLPK(hex_pk=self.key.hex_pk(), hex_vk=self.key.hex_vk())
+
+    def signature(self, msg):
+        return self.key.signature(msg)
+
+    def key_to_bin(self):
+        return "LibNaCLSK:" + dumps({'crypt': self.key.hex_sk(), 'seed': self.key.hex_seed()})

--- a/crypto.py
+++ b/crypto.py
@@ -1,16 +1,14 @@
 from hashlib import sha1
 from math import ceil
 from struct import Struct
-from json import dumps, loads
 import logging
 
 from M2Crypto import EC, BIO
-from M2Crypto.EC import EC_pub
 
 import libnacl.dual
 
 from .util import attach_runtime_statistics
-from libnacl.encode import hex_decode, hex_encode
+from libnacl.encode import hex_encode
 
 _STRUCT_L = Struct(">L")
 
@@ -90,12 +88,12 @@ class DispersyCrypto(object):
 class ECCrypto(DispersyCrypto):
     """
     A crypto object which provides a layer between Dispersy and low level eccrypographic features.
-    
+
     Most methods are implemented by:
         @author: Boudewijn Schoon
         @organization: Technical University Delft
         @contact: dispersy@frayja.com
-        
+
     However since then, most functionality was completely rewritten by:
         @author: Niels Zeilemaker
     """
@@ -157,7 +155,7 @@ class ECCrypto(DispersyCrypto):
         "Returns True if the input is a valid public/private keypair stored in a binary format"
         try:
             self.key_from_private_bin(string)
-        except Exception as e:
+        except:
             return False
         return True
 

--- a/crypto.py
+++ b/crypto.py
@@ -7,6 +7,11 @@ import logging
 from M2Crypto import EC, BIO
 from M2Crypto.EC import EC_pub
 
+# Add libnacl submodule to the python path
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'libnacl'))
+
 import libnacl.dual
 
 from .util import attach_runtime_statistics

--- a/member.py
+++ b/member.py
@@ -1,6 +1,5 @@
 import logging
 
-from M2Crypto.EC import EC_pub, EC
 
 
 class DummyMember(object):
@@ -76,8 +75,9 @@ class Member(DummyMember):
         Create a new Member instance.
         """
         from .dispersy import Dispersy
+        from .crypto import DispersyKey
         assert isinstance(dispersy, Dispersy), type(dispersy)
-        assert isinstance(key, (EC, EC_pub))
+        assert isinstance(key, DispersyKey), type(key)
         assert isinstance(database_id, int), type(database_id)
 
         if not mid:
@@ -86,7 +86,7 @@ class Member(DummyMember):
 
         public_key = dispersy.crypto.key_to_bin(key.pub())
 
-        if key.__class__ is EC:
+        if key.has_secret_key():
             private_key = key
         else:
             private_key = None
@@ -197,7 +197,7 @@ class Member(DummyMember):
     def __eq__(self, member):
         if member:
             assert isinstance(member, DummyMember)
-            assert (self._database_id == member.database_id) == (self._mid == member.mid),  (self._database_id, member.database_id, self._mid, member.mid)
+            assert (self._database_id == member.database_id) == (self._mid == member.mid), (self._database_id, member.database_id, self._mid, member.mid)
             return self._database_id == member.database_id
         return False
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 
 from ..crypto import ECCrypto
 
-
 class TestLowLevelCrypto(TestCase):
 
     @classmethod
@@ -45,16 +44,12 @@ class TestLowLevelCrypto(TestCase):
             self.assertEqual(len(signature), self.crypto.get_signature_length(ec))
             self.assertTrue(self.crypto.is_valid_signature(ec, data, signature))
 
-            #
-            # serialise using BIN
-            #
-
             public = self.crypto.key_to_bin(ec_pub)
-            self.assertTrue(self.crypto.is_valid_public_bin(public))
+            self.assertTrue(self.crypto.is_valid_public_bin(public), public)
             self.assertEqual(public, self.crypto.key_to_bin(ec_pub))
 
             private = self.crypto.key_to_bin(ec)
-            self.assertTrue(self.crypto.is_valid_private_bin(private))
+            self.assertTrue(self.crypto.is_valid_private_bin(private), private)
             self.assertEqual(private, self.crypto.key_to_bin(ec))
 
             ec_clone = self.crypto.key_from_public_bin(public)
@@ -62,18 +57,3 @@ class TestLowLevelCrypto(TestCase):
             ec_clone = self.crypto.key_from_private_bin(private)
             self.assertTrue(self.crypto.is_valid_signature(ec_clone, data, signature))
 
-            #
-            # serialise using PEM
-            #
-
-            public = self.crypto.key_to_pem(ec_pub)
-            self.assertTrue(self.crypto.is_valid_public_pem(public))
-            self.assertEqual(public, self.crypto.key_to_pem(ec_pub))
-            private = self.crypto.key_to_pem(ec)
-            self.assertTrue(self.crypto.is_valid_private_pem(private))
-            self.assertEqual(private, self.crypto.key_to_pem(ec))
-
-            ec_clone = self.crypto.key_from_public_pem(public)
-            self.assertTrue(self.crypto.is_valid_signature(ec_clone, data, signature))
-            ec_clone = self.crypto.key_from_private_pem(private)
-            self.assertTrue(self.crypto.is_valid_signature(ec_clone, data, signature))

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -57,3 +57,21 @@ class TestLowLevelCrypto(TestCase):
             ec_clone = self.crypto.key_from_private_bin(private)
             self.assertTrue(self.crypto.is_valid_signature(ec_clone, data, signature))
 
+    def test_performance(self):
+        from time import time
+        import sys, os
+
+        ec = self.crypto.generate_key(u"very-low")
+
+        data = [os.urandom(1024) for i in xrange(1000)]
+        for curve in [u"very-low", u"low", u"medium", u"high", u"curve25519"]:
+            t1 = time()
+            ec = self.crypto.generate_key(curve)
+            t2 = time()
+            signatures = [self.crypto.create_signature(ec, msg) for msg in data]
+            t3 = time()
+            verfified = [self.crypto.is_valid_signature(ec, msg, signature) for msg, signature in zip(data, signatures)]
+            print >> sys.stderr, curve, "verify", time() - t3, "sign", t3 - t2, "genkey", t2 - t1
+
+            assert all(verfified)
+

--- a/tests/test_member.py
+++ b/tests/test_member.py
@@ -4,12 +4,16 @@ from ..util import call_on_reactor_thread
 
 class TestMember(DispersyTestFunc):
 
-    @call_on_reactor_thread
     def test_verify(self):
+        self._test_verify(u"medium")
+        self._test_verify(u"curve25519")
+
+    @call_on_reactor_thread
+    def _test_verify(self, curve):
         """
         Test test member.verify assuming create_signature works properly.
         """
-        ec = self._dispersy.crypto.generate_key(u"medium")
+        ec = self._dispersy.crypto.generate_key(curve)
         member = self._dispersy.get_member(private_key=self._dispersy.crypto.key_to_bin(ec))
 
         # sign and verify "0123456789"[0:10]
@@ -64,12 +68,17 @@ class TestMember(DispersyTestFunc):
         self.assertFalse(member.verify("0123456789", self._dispersy.crypto.create_signature(ec, "12345678"), offset=1, length=666))
         self.assertFalse(member.verify("0123456789E", self._dispersy.crypto.create_signature(ec, "12345678"), offset=1, length=666))
 
-    @call_on_reactor_thread
+
     def test_sign(self):
+        self._test_sign(u"medium")
+        self._test_sign(u"curve25519")
+
+    @call_on_reactor_thread
+    def _test_sign(self, curve):
         """
         Test test member.sign assuming is_valid_signature works properly.
         """
-        ec = self._dispersy.crypto.generate_key(u"medium")
+        ec = self._dispersy.crypto.generate_key(curve)
         member = self._dispersy.get_member(private_key=self._dispersy.crypto.key_to_bin(ec))
 
         # sign and verify "0123456789"[0:10]


### PR DESCRIPTION
Implemented curve25519 support for dispersy, members can be constructed from a curve25519 key. This paves the way for the tunnelcommunity swtiching to curve25519 keys.
It uses
- libnacl, install using pip install libnacl
- libsodium, i used the pre-compiled dll file for windows from https://github.com/adamcaudill/libsodium-net/releases. Alternatively tweetnacl can be used.

Tested barebone signing/verifying using test_crypto, signing/verifying using test_member.
