### PR TITLE
Fixed/extended doublememberauth

### DIFF
--- a/tests/debugcommunity/community.py
+++ b/tests/debugcommunity/community.py
@@ -192,9 +192,16 @@ class DebugCommunity(Community):
         Must return either: a. the same message, b. a modified version of message, or c. None.
         """
         self._logger.debug("%s \"%s\"", message, message.payload.text)
-        assert message.payload.text.startswith("Allow=True") or message.payload.text.startswith("Allow=False")
-        if message.payload.text.startswith("Allow=True"):
+        allow_text = message.payload.text
+        assert allow_text in ["Allow=True", "Allow=False", "Allow=Modify"]  
+        if allow_text == "Allow=True":
             return message
+        
+        if allow_text == "Allow=Modify":
+            meta = message.meta
+            return meta.impl(authentication=(message.authentication.members,),
+                         distribution=(message.distribution.global_time,),
+                         payload=("MODIFIED",))
 
     def on_text(self, messages):
         """

--- a/tests/debugcommunity/community.py
+++ b/tests/debugcommunity/community.py
@@ -193,11 +193,11 @@ class DebugCommunity(Community):
         """
         self._logger.debug("%s \"%s\"", message, message.payload.text)
         allow_text = message.payload.text
-        assert allow_text in ["Allow=True", "Allow=False", "Allow=Modify"]  
-        if allow_text == "Allow=True":
+        assert allow_text.startswith("Allow=True") or allow_text.startswith("Allow=False") or allow_text.startswith("Allow=Modify")  
+        if allow_text.startswith("Allow=True"):
             return message
         
-        if allow_text == "Allow=Modify":
+        if allow_text.startswith("Allow=Modify"):
             meta = message.meta
             return meta.impl(authentication=(message.authentication.members,),
                          distribution=(message.distribution.global_time,),

--- a/tests/debugcommunity/node.py
+++ b/tests/debugcommunity/node.py
@@ -677,7 +677,7 @@ class DebugNode(object):
                          payload=(text,))
 
     @blocking_call_on_reactor_thread
-    def _create_doublemember_text(self, message_name, other, text, sign, global_time=None):
+    def _create_doublemember_text(self, message_name, other, text, global_time=None):
         assert isinstance(message_name, unicode)
         assert isinstance(other, Member)
         assert isinstance(text, str)
@@ -694,8 +694,7 @@ class DebugNode(object):
 
         return meta.impl(authentication=([self._my_member, my_other],),
                          distribution=(global_time,),
-                         payload=(text,),
-                         sign=sign)
+                         payload=(text,))
 
     def create_last_1_test(self, text, global_time=None):
         """
@@ -709,17 +708,17 @@ class DebugNode(object):
         """
         return self._create_text(u"last-9-test", text, global_time)
 
-    def create_last_1_doublemember_text(self, other, text, sign, global_time=None):
+    def create_last_1_doublemember_text(self, other, text, global_time=None):
         """
         Returns a new last-1-doublemember-text message.
         """
-        return self._create_doublemember_text(u"last-1-doublemember-text", other, text, sign, global_time)
+        return self._create_doublemember_text(u"last-1-doublemember-text", other, text, global_time)
 
-    def create_double_signed_text(self, other, text, sign, global_time=None):
+    def create_double_signed_text(self, other, text, global_time=None):
         """
         Returns a new double-signed-text message.
         """
-        return self._create_doublemember_text(u"double-signed-text", other, text, sign, global_time)
+        return self._create_doublemember_text(u"double-signed-text", other, text, global_time)
 
     def create_full_sync_text(self, text, global_time=None):
         """

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -63,9 +63,9 @@ class TestDoubleSign(DispersyTestFunc):
         def on_response(request, response, modified):
             self.assertIsNone(response)
             container["timeout"] += 1
-            return False, False, False
+            return False
 
-        message = other.create_double_signed_text(node.my_pub_member, "Allow=True", False)
+        message = other.create_double_signed_text(node.my_pub_member, "Allow=True")
         other.call(other._community.create_signature_request, node.my_candidate, message, on_response, timeout=1.0)
 
         sleep(1.5)
@@ -89,16 +89,18 @@ class TestDoubleSign(DispersyTestFunc):
             mid_signatures = dict([(member.mid, signature) for signature, member in response.authentication.signed_members])
             # It should be signed by OTHER
             self.assertNotEqual(mid_signatures[other.my_member.mid], '')
-            # BUT it should not be signed by NODE yet
-            self.assertEqual(mid_signatures[node.my_member.mid], '')
-            # is_signed should be False, as it is not yet signed by both parties
-            self.assertFalse(response.authentication.is_signed)
+            
+            # AND it should be signed by NODE as the payload did not change
+            self.assertNotEqual(mid_signatures[node.my_member.mid], '')
+            
+            # is_signed should be True, as it is signed by both parties
+            self.assertTrue(response.authentication.is_signed)
             self.assertFalse(modified)
             container["response"] += 1
             return False
 
         # NODE creates the unsigned request and sends it to OTHER
-        message = node.create_double_signed_text(other.my_pub_member, "Allow=True", False)
+        message = node.create_double_signed_text(other.my_pub_member, "Allow=True")
         node.call(node._community.create_signature_request, other.my_candidate, message, on_response, timeout=1.0)
 
         # OTHER receives the request
@@ -107,7 +109,58 @@ class TestDoubleSign(DispersyTestFunc):
 
         second_signature_offset = len(submsg.packet) - other.my_member.signature_length
         first_signature_offset = second_signature_offset - node.my_member.signature_length
-        self.assertEqual(submsg.packet[first_signature_offset:second_signature_offset], "\x00" * node.my_member.signature_length, "The first signature MUST BE 0x00's.")
+        self.assertNotEqual(submsg.packet[first_signature_offset:second_signature_offset], "\x00" * node.my_member.signature_length, "The first signature MUST BE 0x00's.")
+        self.assertEqual(submsg.packet[second_signature_offset:], "\x00" * other.my_member.signature_length, "The second signature MUST BE 0x00's.")
+
+        # reply sent by OTHER is ok, give it to NODE to process it
+        other.give_message(message, node)
+        node.process_packets()
+
+        sleep(1.5)
+
+        self.assertEqual(container["response"], 1)
+        
+    def test_modified_response_from_node(self):
+        """
+        NODE will request a signature from OTHER.
+        NODE will receive the response signed by OTHER.
+        """
+        container = {"response": 0}
+
+        node, other = self.create_nodes(2)
+        other.send_identity(node)
+
+        def on_response(request, response, modified):
+            self.assertNotEqual(response, None)
+            
+            self.assertEqual(container["response"], 0)
+            mid_signatures = dict([(member.mid, signature) for signature, member in response.authentication.signed_members])
+            
+            # It should be signed by OTHER
+            self.assertNotEqual(mid_signatures[other.my_member.mid], '')
+            
+            # BUT it should not be signed by NODE yet, because the payload changed
+            self.assertEqual(mid_signatures[node.my_member.mid], '')
+            
+            # is_signed should be False, as it is not yet signed by both parties
+            self.assertFalse(response.authentication.is_signed)
+            self.assertTrue(modified)
+            self.assertEqual(response.payload.text, "MODIFIED")
+            
+            container["response"] += 1
+            return False
+
+        # NODE creates the unsigned request and sends it to OTHER
+        message = node.create_double_signed_text(other.my_pub_member, "Allow=Modify")
+        node.call(node._community.create_signature_request, other.my_candidate, message, on_response, timeout=1.0)
+
+        # OTHER receives the request
+        _, message = other.receive_message(names=[u"dispersy-signature-request"]).next()
+        submsg = message.payload.message
+
+        second_signature_offset = len(submsg.packet) - other.my_member.signature_length
+        first_signature_offset = second_signature_offset - node.my_member.signature_length
+        self.assertNotEqual(submsg.packet[first_signature_offset:second_signature_offset], "\x00" * node.my_member.signature_length, "The first signature MUST BE 0x00's.")
         self.assertEqual(submsg.packet[second_signature_offset:], "\x00" * other.my_member.signature_length, "The second signature MUST BE 0x00's.")
 
         # reply sent by OTHER is ok, give it to NODE to process it

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -249,7 +249,7 @@ class TestSync(DispersyTestFunc):
             destination_mid_pre = destination._community.my_member.mid
             assert origin_mid_pre != destination_mid_pre
 
-            submsg = origin.create_last_1_doublemember_text(destination.my_member, message, True, global_time)
+            submsg = origin.create_last_1_doublemember_text(destination.my_member, message, global_time)
 
             assert origin_mid_pre == origin._community.my_member.mid
             assert destination_mid_pre == destination._community.my_member.mid


### PR DESCRIPTION
When a message is modified, the sender signature is reset. But if accepted unmodified, then both signatures would be set after Bob accepts it.
