### PR TITLE
Added DoubleMemberAuthentication.signatures

### DIFF
--- a/authentication.py
+++ b/authentication.py
@@ -291,6 +291,14 @@ class DoubleMemberAuthentication(Authentication):
             return self._members
 
         @property
+        def signatures(self):
+            """
+            The signatures of the message that have been signed, or if missing "".
+            @rtype: list or tuple containing String instances
+            """
+            return self._signatures
+
+        @property
         def signed_members(self):
             """
             The members and their signatures.


### PR DESCRIPTION
You need the signatures when you respond to a request with properties that you need to set in append mode. The properties in  a payload do not allow you to change them. So you need to create a new message, but you do not want to lose the signatures already set.

This allows you to get the signatures and add them to the new message.
