### PR TITLE
Openssl applink fix

### DIFF
--- a/crypto.py
+++ b/crypto.py
@@ -334,7 +334,10 @@ class M2CryptoSK(M2CryptoPK):
             self.ec = self.key_from_pem("-----BEGIN EC PRIVATE KEY-----\n%s-----END EC PRIVATE KEY-----\n" % keystring.encode("BASE64"))
 
         elif filename:
-            self.ec = EC.load_key(filename)
+            # this workaround is needed to run Tribler on Windows 64 bit
+            membuf = BIO.MemoryBuffer(open(filename, 'rb').read())
+            self.ec = EC.load_key_bio(membuf)
+            membuf.close()
 
     def pub(self):
         return M2CryptoPK(ec_pub=self.ec.pub())


### PR DESCRIPTION
On Windows, I encountered an issue when setting up a 64-bit environment. The problem occurred when invoking M2Crypto functions. I've explained the issue in more detail on Stack Overflow here.

One solution for this problem is to recompile Python and to include openssl/applink.c in the Python.c file. Since recompiling Python turned out to be quite hard (and not very desirable), I believe we can use the workaround as given by the answer on Stack Overflow. By making use of M2Crypto.BIO, we avoid using the openssl applink interface and thus the No OPENSSL_AppLink error.

Note that this problem only occurs on Windows (and I believe in particular 64-bit builds). On Linux and OS X, it is working without any problem.

I've also submitted a PR on Tribler, see [here](https://github.com/Tribler/tribler/pull/1731).
