### PR TITLE
Temporary fork/fix for libnacl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libnacl"]
 	path = libnacl
-	url = https://github.com/saltstack/libnacl
+	url = https://github.com/whirm/libnacl


### PR DESCRIPTION
Makes it use libsodium18.so if found so it works on recent Debian/Ubuntu versions.
