### PR TITLE
WIP: Remove the netifaces dependency

### DIFF
--- a/tests/test_nat_detection.py
+++ b/tests/test_nat_detection.py
@@ -123,6 +123,20 @@ class TestAddressEstimation(DispersyTestFunc):
         self.assertFalse(address_is_lan_without_netifaces("123.123.123.123"))
         self.assertFalse(address_is_lan_without_netifaces("42.42.42.42"))
 
+    def test_address_in_lan_function(self):
+        # Positive cases:
+        assert self._dispersy.address_is_lan("192.168.1.5")
+        assert self._dispersy.address_is_lan("10.42.42.42")
+        assert self._dispersy.address_is_lan("192.168.0.7")
+        assert self._dispersy.address_is_lan("172.31.255.255")
+        #Negative cases:
+        self.assertFalse(self._dispersy.address_is_lan("192.169.1.5"))
+        self.assertFalse(self._dispersy.address_is_lan("11.42.42.42"))
+        self.assertFalse(self._dispersy.address_is_lan("192.0.0.7"))
+        self.assertFalse(self._dispersy.address_is_lan("172.32.0.0"))
+        self.assertFalse(self._dispersy.address_is_lan("123.123.123.123"))
+        self.assertFalse(self._dispersy.address_is_lan("42.42.42.42"))
+
     def test_estimate_addresses_within_LAN(self):
         """
         Tests the estimate_lan_and_wan_addresses method while NODE and OTHER are within the same LAN.
@@ -167,5 +181,3 @@ class TestAddressEstimation(DispersyTestFunc):
             self.assertEqual(candidate.sock_addr, node.lan_address)
             self.assertEqual(candidate.lan_address, node.lan_address)
             self.assertEqual(candidate.wan_address, incorrect_WAN)
-
-


### PR DESCRIPTION
Instead use the standard 'socket' library.

This is hard to test for all kinds of NAT and network setups, and it might result in non critical failures, so it might be hard to verify.

Another option is to only use this method as a fallback when netifaces fails.
