### PR TITLE
Make sure the discover community also unloads its bootstrap and its loopingcall if exists

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -143,7 +143,7 @@ class TestBootstrapServers(DispersyTestFunc):
             @inlineCallbacks
             def start_walking(self):
                 for _ in xrange(10):
-                    if self._dispersy._discovery_community and self._dispersy._discovery_community.bootstrap.are_resolved:
+                    if self._dispersy._discovery_community and self._dispersy._discovery_community.bootstrap.all_resolved:
                         self._pcandidates = [self.get_candidate(address) for address in
                                              set(self._dispersy._discovery_community.bootstrap.candidate_addresses)]
                         break


### PR DESCRIPTION
Fixes **1** bug and an issue on Tribler.
Refactors bootstrap to make use of the TaskManager (enhancement)
Haven't seen the delayed reactor call with this change after running the tests on Tribler quite a bit.

Fun fact: the Bootstrap stop() function was never called anywhere. Now it is :D
