### PR TITLE
log exception type

### DIFF
--- a/util.py
+++ b/util.py
@@ -234,8 +234,8 @@ def blockingCallFromThread(reactor, f, *args, **kwargs):
         if isinstance(result, failure.Failure):
             other_thread_tb = traceback.extract_tb(result.getTracebackObject())
             this_thread_tb = traceback.extract_stack()
-            logger.error("Exception raised on the reactor's thread '%s'.\n Traceback from this thread:\n%s\n"
-                         " Traceback from the reactor's thread:\n %s", result.getErrorMessage(),
+            logger.error("Exception raised on the reactor's thread %s: \"%s\".\n Traceback from this thread:\n%s\n"
+                         " Traceback from the reactor's thread:\n %s", result.type.__name__, result.getErrorMessage(),
                          ''.join(traceback.format_list(this_thread_tb)), ''.join(traceback.format_list(other_thread_tb)))
             result.raiseException()
         return result


### PR DESCRIPTION
To trace what type of exception we need to catch from this test:
https://jenkins.tribler.org/job/GH_Tribler_PR_tests_linux/2411/testReport/Tribler.Test.Community.Multichain.test_multichain_community/TestMultiChainCommunity/test_on_tunnel_remove_NoneType/
