### PR TITLE
Ensure _get_interface_addresses always returns IP addresses as str

### DIFF
--- a/dispersy.py
+++ b/dispersy.py
@@ -202,7 +202,13 @@ class Dispersy(TaskManager):
                 else:
                     for option in addresses.get(netifaces.AF_INET, []):
                         try:
-                            yield Interface(interface, option.get("addr"), option.get("netmask"), option.get("broadcast"))
+                            # On Windows netifaces currently returns IP addresses as unicode,
+                            # and on *nix it returns str. So, we convert any unicode objects to str.
+                            unicode_to_str = lambda s: s.encode('utf-8') if isinstance(s, unicode) else s
+                            yield Interface(interface,
+                                            unicode_to_str(option.get("addr")),
+                                            unicode_to_str(option.get("netmask")),
+                                            unicode_to_str(option.get("broadcast")))
 
                         except TypeError:
                             # some interfaces have no netmask configured, causing a TypeError when


### PR DESCRIPTION
On my Windows machine an assert is firing due to an unicode IP address being returned from _get_interface_addresses (instead of a str). Apparently it's due to netifaces returning an unicode object on Windows (https://bitbucket.org/al45tair/netifaces/issues/41/address-info-unicode-on-windows-byte).