### PR TITLE
Catch rogue (twisted) threads in unit test teardown

### DIFF
--- a/tests/test_taskmanager.py
+++ b/tests/test_taskmanager.py
@@ -11,6 +11,8 @@ class TaskManagerTestFunc(DispersyTestFunc):
 
     @blocking_call_on_reactor_thread
     def setUp(self):
+        super(TaskManagerTestFunc, self).setUp()
+
         self.dispersy_objects = []
         self.tm = TaskManager()
         self.tm._reactor = Clock()


### PR DESCRIPTION
This PR adds checking for unclosed reactor threads and normal threads on test `tearDown` in `DispersyTestFunc`.