### PR TITLE
Added keep-alive option to WCandidates

### DIFF
--- a/community.py
+++ b/community.py
@@ -1069,6 +1069,12 @@ class Community(TaskManager):
 
         self.dispersy.detach_community(self)
 
+    def is_loaded(self):
+        """
+        Returns whether this community is attached to Dispersy
+        """
+        return self in self.dispersy.get_communities()
+
     def claim_global_time(self):
         """
         Increments the current global time by one and returns this value.
@@ -2740,6 +2746,26 @@ class Community(TaskManager):
             self._dispersy._forward([request])
 
         return request
+
+    def send_keep_alive(self, candidate):
+        """
+        Request a response from a candidate. If does not answer, let it time out.
+
+        The implementation of this mechanism uses an IntroductionRequest without any
+        piggybacked data. So, we don't receive any introductions or bloomfilters etc.
+        """
+        assert isinstance(candidate, WalkCandidate), [type(candidate), candidate]
+
+        cache = self.request_cache.add(IntroductionRequestCache(self, candidate))
+        args_list = [candidate.sock_addr, self._dispersy._lan_address, self._dispersy._wan_address, False,
+                     self._dispersy._connection_type, None, cache.number]
+
+        meta_request = self.get_meta_message(u"dispersy-introduction-request")
+        request = meta_request.impl(authentication=(self.my_member,),
+                                    distribution=(self.global_time,),
+                                    destination=(candidate,),
+                                    payload=tuple(args_list))
+        self._dispersy._forward([request])
 
     def _get_packets_for_bloomfilters(self, requests, include_inactive=True):
         """


### PR DESCRIPTION
This PR adds the option for WalkCandidates to stay alive for a certain community (see `WalkCandidate.set_keepalive`).

Once the WalkCandidate determines it has timed out for its respective category (see `WalkCandidate.get_category`), send a light-weight introduction request, without sync or advice so we are not introduced to new peers (see `Community.send_keep_alive`). If this does not get answered with an introduction response within the next timeout cycle, the WalkCandidate is timed out after all.

## For developers

If your community wants to keep a certain WalkCandidate as long as possible, call `candidate.set_keepalive(community)` to keep it until it goes offline. If you are no longer interested, call `candidate.set_keepalive(None)`.