### PR TITLE
READY: Removed sleeps from tests

### DIFF
--- a/endpoint.py
+++ b/endpoint.py
@@ -378,6 +378,11 @@ class ManualEnpoint(StandaloneEndpoint):
         self.process_packets(packets)
         return packets
 
-    def process_packets(self, packets, cache=True):
+    def process_packets(self, packets, cache=False):
         self._logger.debug('processing %d packets', len(packets))
-        StandaloneEndpoint.data_came_in(self, packets, cache=cache)
+
+        self._dispersy.statistics.total_down += sum(len(data) for _, data in packets)
+        if self._logger.isEnabledFor(logging.DEBUG):
+            for sock_addr, data in packets:
+                self.log_packet(sock_addr, data, outbound=False)
+        self.dispersythread_data_came_in(packets, time(), cache)

--- a/tests/dispersytestclass.py
+++ b/tests/dispersytestclass.py
@@ -100,7 +100,6 @@ class DispersyTestFunc(TestCase):
                 self._logger.error("Found rogue thread: %s", thread)
         self.assertFalse(rogue_threads, "Rogue threads active, see log")
 
-    @blocking_call_on_reactor_thread
     @inlineCallbacks
     def create_nodes(self, amount=1, store_identity=True, tunnel=False, community_class=DebugCommunity,
                      autoload_discovery=False, memory_database=True):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -201,7 +201,7 @@ class TestBootstrapServers(DispersyTestFunc):
             packet = node.fetch_packets([u"dispersy-identity", ], node.my_member.mid)[0]
             node.send_packet(packet, destination)
 
-            node.process_packets()
+            yield node.process_packets()
 
             _, message = node.receive_message(names=[u"dispersy-identity"]).next()
 

--- a/tests/test_destroycommunity.py
+++ b/tests/test_destroycommunity.py
@@ -1,8 +1,13 @@
+from twisted.internet.defer import inlineCallbacks
+
 from .dispersytestclass import DispersyTestFunc
+from ..util import blocking_call_on_reactor_thread
 
 
 class TestDestroyCommunity(DispersyTestFunc):
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_hard_kill(self):
         """
         Test that a community can be hard killed and their messages will be dropped from the DB.
@@ -11,7 +16,7 @@ class TestDestroyCommunity(DispersyTestFunc):
         3. MM destroys the community.
         4. Node wipes all messages from the community in the database.
         """
-        node, = self.create_nodes(1)
+        node, = yield self.create_nodes(1)
 
         message = node.create_full_sync_text("Should be removed", 42)
         node.give_message(message, node)
@@ -24,8 +29,10 @@ class TestDestroyCommunity(DispersyTestFunc):
 
         node.assert_count(message, 0)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_hard_kill_without_permission(self):
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         node.send_identity(other)
 
         message = node.create_full_sync_text("Should not be removed", 42)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,9 +1,7 @@
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, returnValue
 from .dispersytestclass import DispersyTestFunc
-from ..discovery.community import DiscoveryCommunity, BOOTSTRAP_FILE_ENVNAME
+from ..discovery.community import DiscoveryCommunity
 from ..discovery.bootstrap import _DEFAULT_ADDRESSES
-import os
-import time
 from ..util import blocking_call_on_reactor_thread
 
 
@@ -16,21 +14,24 @@ class TestDiscovery(DispersyTestFunc):
             _DEFAULT_ADDRESSES.pop()
         yield super(TestDiscovery, self).setUp()
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_overlap(self):
         def get_preferences():
             return ['0' * 20, '1' * 20]
         self._community.my_preferences = get_preferences
 
-        node,  = self.create_nodes(1)
+        node, = yield self.create_nodes(1)
         node._community.my_preferences = get_preferences
 
-        node.process_packets()
-        self._mm.process_packets()
-        time.sleep(1)
+        yield node.process_packets()
+        yield self._mm.process_packets(timeout=2.0)
 
         assert node._community.is_taste_buddy_mid(self._mm.my_mid)
         assert self._mm._community.is_taste_buddy_mid(node.my_mid)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_introduction(self):
         def get_preferences(node_index):
             return [str(i) * 20 for i in range(node_index, node_index + 2)]
@@ -43,17 +44,16 @@ class TestDiscovery(DispersyTestFunc):
 
         self._community.my_preferences = lambda: get_preferences(0)
 
-        node,  = self.create_nodes(1)
+        node, = yield self.create_nodes(1)
         node._community.my_preferences = lambda: get_preferences(1)
 
-        node.process_packets()
-        self._mm.process_packets()
-        time.sleep(1)
+        yield node.process_packets()
+        yield self._mm.process_packets(timeout=2.0)
 
         assert node._community.is_taste_buddy_mid(self._mm.my_mid)
         assert self._mm._community.is_taste_buddy_mid(node.my_mid)
 
-        other,  = self.create_nodes(1)
+        other, = yield self.create_nodes(1)
         other._community.my_preferences = lambda: get_preferences(2)
         orig_method = other._community.get_most_similar
         other._community.get_most_similar = lambda candidate: get_most_similar(orig_method, candidate)
@@ -61,9 +61,8 @@ class TestDiscovery(DispersyTestFunc):
         other._community.add_discovered_candidate(self._mm.my_candidate)
         other.take_step()
 
-        self._mm.process_packets()
-        other.process_packets()
-        time.sleep(1)
+        yield self._mm.process_packets()
+        yield other.process_packets(timeout=2.0)
 
         # other and mm should not be taste buddies
         assert not other._community.is_taste_buddy_mid(self._mm.my_mid)
@@ -72,5 +71,7 @@ class TestDiscovery(DispersyTestFunc):
         # other should have requested an introduction to node
         assert most_similar[-1][1] == node.my_mid
 
+    @inlineCallbacks
     def create_nodes(self, *args, **kwargs):
-        return super(TestDiscovery, self).create_nodes(*args, community_class=DiscoveryCommunity, **kwargs)
+        out = yield super(TestDiscovery, self).create_nodes(*args, community_class=DiscoveryCommunity, **kwargs)
+        returnValue(out)

--- a/tests/test_dynamicsettings.py
+++ b/tests/test_dynamicsettings.py
@@ -1,14 +1,19 @@
+from twisted.internet.defer import inlineCallbacks
+
 from ..resolution import PublicResolution, LinearResolution
+from ..util import blocking_call_on_reactor_thread
 from .dispersytestclass import DispersyTestFunc
 
 
 class TestDynamicSettings(DispersyTestFunc):
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_default_resolution(self):
         """
         Ensure that the default resolution policy is used first.
         """
-        other, = self.create_nodes(1)
+        other, = yield self.create_nodes(1)
 
         meta = self._community.get_meta_message(u"dynamic-resolution-text")
 
@@ -23,11 +28,13 @@ class TestDynamicSettings(DispersyTestFunc):
 
         other.assert_is_stored(message)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_change_resolution(self):
         """
         Change the resolution policy from default to linear.
         """
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         other.send_identity(node)
 
         meta = node._community.get_meta_message(u"dynamic-resolution-text")
@@ -62,6 +69,8 @@ class TestDynamicSettings(DispersyTestFunc):
         other.give_message(message, node)
         other.assert_not_stored(message)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_change_resolution_undo(self):
         """
         Change the resolution policy from default to linear, the messages already accepted should be
@@ -72,7 +81,7 @@ class TestDynamicSettings(DispersyTestFunc):
                 policy, _ = other.get_resolution_policy(meta, global_time)
                 self.assertIsInstance(policy, policyclass)
 
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         other.send_identity(node)
 
         meta = self._community.get_meta_message(u"dynamic-resolution-text")
@@ -113,6 +122,8 @@ class TestDynamicSettings(DispersyTestFunc):
         # policy change should have redone the tmessage
         other.assert_is_done(tmessage)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_change_resolution_reject(self):
         """
         Change the resolution policy from default to linear and back, to see if other requests the proof
@@ -122,7 +133,7 @@ class TestDynamicSettings(DispersyTestFunc):
                 policy, _ = other.get_resolution_policy(meta, global_time)
                 self.assertIsInstance(policy, policyclass)
 
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         other.send_identity(node)
 
         meta = self._community.get_meta_message(u"dynamic-resolution-text")
@@ -153,6 +164,8 @@ class TestDynamicSettings(DispersyTestFunc):
         other.give_message(policy_public, self._mm)
         other.assert_is_done(tmessage)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_change_resolution_send_proof(self):
         """
         Change the resolution policy from default to linear and back, to see if other sends the proofs
@@ -162,7 +175,7 @@ class TestDynamicSettings(DispersyTestFunc):
                 policy, _ = other.get_resolution_policy(meta, global_time)
                 self.assertIsInstance(policy, policyclass)
 
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         other.send_identity(node)
 
         meta = self._community.get_meta_message(u"dynamic-resolution-text")

--- a/tests/test_identicalpayload.py
+++ b/tests/test_identicalpayload.py
@@ -1,14 +1,19 @@
+from twisted.internet.defer import inlineCallbacks
+
 from .dispersytestclass import DispersyTestFunc
+from ..util import blocking_call_on_reactor_thread
 
 
 class TestIdenticalPayload(DispersyTestFunc):
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_drop_identical_payload(self):
         """
         NODE creates two messages with the same community/member/global-time.
         Sends both of them to OTHER, which should drop the "lowest" one.
         """
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         other.send_identity(node)
 
         # create messages
@@ -27,11 +32,13 @@ class TestIdenticalPayload(DispersyTestFunc):
         other.assert_not_stored(messages[0])
         other.assert_is_stored(messages[1])
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_drop_identical(self):
         """
         NODE creates one message, sends it to OTHER twice
         """
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         other.send_identity(node)
 
         # create messages

--- a/tests/test_missingidentity.py
+++ b/tests/test_missingidentity.py
@@ -1,31 +1,38 @@
+from twisted.internet.defer import inlineCallbacks
+
 from .dispersytestclass import DispersyTestFunc
+from ..util import blocking_call_on_reactor_thread
 
 
 class TestMissingIdentity(DispersyTestFunc):
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_incoming_missing_identity(self):
         """
         NODE generates a missing-identity message and OTHER responds.
         """
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         node.send_identity(other)
 
         # use NODE to fetch the identities for OTHER
         other.give_message(node.create_missing_identity(other.my_member, 10), node)
 
         # MISSING should reply with a dispersy-identity message
-        responses = node.receive_messages()
+        responses = yield node.receive_messages()
 
         self.assertEqual(len(responses), 1)
         for _, response in responses:
             self.assertEqual(response.name, u"dispersy-identity")
             self.assertEqual(response.authentication.member.public_key, other.my_member.public_key)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_outgoing_missing_identity(self):
         """
         NODE generates data and sends it to OTHER, resulting in OTHER asking for the other identity.
         """
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
 
         # Give OTHER a message from NODE
         message = node.create_full_sync_text("Hello World", 10)
@@ -35,7 +42,7 @@ class TestMissingIdentity(DispersyTestFunc):
         other.assert_not_stored(message)
 
         # OTHER must send a missing-identity to NODEs
-        responses = node.receive_messages()
+        responses = yield node.receive_messages()
         self.assertEqual(len(responses), 1)
         for _, response in responses:
             self.assertEqual(response.name, u"dispersy-missing-identity")
@@ -47,11 +54,13 @@ class TestMissingIdentity(DispersyTestFunc):
         # OTHER must now process and store the 'Hello World' message
         other.assert_is_stored(message)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_outgoing_missing_identity_twice(self):
         """
         NODE generates data and sends it to OTHER twice, resulting in OTHER asking for the other identity once.
         """
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
 
         # Give OTHER a message from NODE
         message = node.create_full_sync_text("Hello World", 10)
@@ -64,7 +73,7 @@ class TestMissingIdentity(DispersyTestFunc):
         other.give_message(message, node)
 
         # OTHER must send a single missing-identity to NODE
-        responses = node.receive_messages()
+        responses = yield node.receive_messages()
         self.assertEqual(len(responses), 1)
         for _, response in responses:
             self.assertEqual(response.name, u"dispersy-missing-identity")

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,16 +1,19 @@
-from time import sleep
+from twisted.internet.defer import inlineCallbacks
 
 from .dispersytestclass import DispersyTestFunc
+from ..util import blocking_call_on_reactor_thread
 
 
 class TestSignature(DispersyTestFunc):
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_invalid_public_key(self):
         """
         NODE sends a message containing an invalid public-key to OTHER.
         OTHER should drop it
         """
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         other.send_identity(node)
 
         message = node.create_bin_key_text('Should drop')
@@ -28,12 +31,14 @@ class TestSignature(DispersyTestFunc):
 
         self.assertEqual(other.fetch_messages([u"bin-key-text", ]), [])
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def test_invalid_signature(self):
         """
         NODE sends a message containing an invalid signature to OTHER.
         OTHER should drop it
         """
-        node, other = self.create_nodes(2)
+        node, other = yield self.create_nodes(2)
         other.send_identity(node)
 
         message = node.create_full_sync_text('Should drop')

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,4 +1,7 @@
+from twisted.internet.defer import inlineCallbacks, returnValue
+
 from .dispersytestclass import DispersyTestFunc
+from ..util import blocking_call_on_reactor_thread
 
 
 class TestWalker(DispersyTestFunc):
@@ -14,16 +17,18 @@ class TestWalker(DispersyTestFunc):
     def test_two_mixed_walker_b(self): return self.check_walker(["t", ""])
     def test_many_mixed_walker_b(self): return self.check_walker(["t", ""] * 11)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def create_others(self, all_flags):
         assert isinstance(all_flags, list)
         assert all(isinstance(flags, str) for flags in all_flags)
 
         nodes = []
         for flags in all_flags:
-            node, = self.create_nodes(tunnel="t" in flags)
+            node, = yield self.create_nodes(tunnel="t" in flags)
             nodes.append(node)
 
-        return nodes
+        returnValue(nodes)
 
     def check_walker(self, all_flags):
         """


### PR DESCRIPTION
This PR twistifies all sleep calls in the unit test code, EXCEPT in `test_bootstrap` (as this uses sleeps to control external processes). 

I recommend reviewing `test_double_signature` in [split diff mode](https://github.com/Tribler/dispersy/pull/549/files?diff=split), as this class had all of its Widows line endings (\r\n) replaced with Nix endings (\n).

NOTE: The multichain Tribler test will have to be updated to work with this PR.