### PR TITLE
Logging stderr to log file

### DIFF
--- a/scripts/dispersy-tracker@.service
+++ b/scripts/dispersy-tracker@.service
@@ -9,7 +9,7 @@ Environment="PYTHONPATH=/opt/dispersy"
 WorkingDirectory=/opt
 
 ExecStartPre=/bin/mkdir -p ${HOME}/%i
-ExecStart=/usr/bin/twistd --nodaemon --pidfile= tracker --port=%i --statedir=${HOME}/%i
+ExecStart=/usr/bin/twistd --nodaemon --pidfile= tracker --port=%i --statedir=${HOME}/%i --loglevel ${TRACKER_LOGLEVEL}
 
 User=dispersy_tracker
 Group=dispersy_tracker


### PR DESCRIPTION
It's important to see what's going on when running Dispersy trackers. This PR makes sure that stderr output is written to the `dispersy.log` file.